### PR TITLE
Fix index-based ForEach crash

### DIFF
--- a/Cauldron/Views/AddRecipe/IngredientsSection.swift
+++ b/Cauldron/Views/AddRecipe/IngredientsSection.swift
@@ -50,9 +50,9 @@ struct IngredientsSection: View {
             // Items container
             ZStack(alignment: .top) {
                 VStack(spacing: isEditMode ? 5 : 10) {
-                    ForEach(ingredients.indices, id: \.self) { index in
+                    ForEach(Array($ingredients.enumerated()), id: \.[1].id) { index, $ingredient in
                         if isEditMode {
-                            let item = ingredients[index]
+                            let item = $ingredient.wrappedValue
                             let isLastPlaceholder = index == ingredients.count - 1 && (item.name.isEmpty || item.isPlaceholder)
                             
                             HStack {
@@ -66,11 +66,11 @@ struct IngredientsSection: View {
                                 
                                 // Use direct binding to ensure changes are saved
                                 IngredientInputRow(
-                                    name: $ingredients[index].name,
-                                    quantityString: $ingredients[index].quantityString,
-                                    unit: $ingredients[index].unit,
-                                    isFocused: $ingredients[index].isFocused,
-                                    ingredientId: ingredients[index].id
+                                    name: $ingredient.name,
+                                    quantityString: $ingredient.quantityString,
+                                    unit: $ingredient.unit,
+                                    isFocused: $ingredient.isFocused,
+                                    ingredientId: $ingredient.id
                                 )
                                 
                                 // Delete button
@@ -164,21 +164,21 @@ struct IngredientsSection: View {
                             )
                         } else {
                             IngredientInputRow(
-                                name: $ingredients[index].name,
-                                quantityString: $ingredients[index].quantityString,
-                                unit: $ingredients[index].unit,
-                                isFocused: $ingredients[index].isFocused,
-                                ingredientId: ingredients[index].id
+                                name: $ingredient.name,
+                                quantityString: $ingredient.quantityString,
+                                unit: $ingredient.unit,
+                                isFocused: $ingredient.isFocused,
+                                ingredientId: $ingredient.id
                             )
-                            .onChange(of: ingredients[index].isFocused) {
-                                if ingredients[index].isFocused { checkAndAddPlaceholder() }
+                            .onChange(of: $ingredient.isFocused) {
+                                if $ingredient.isFocused { checkAndAddPlaceholder() }
                             }
-                            .onChange(of: ingredients[index].name) { 
-                                if index == ingredients.count - 1 && !ingredients[index].name.isEmpty {
-                                    withAnimation { 
-                                        ingredients.append(IngredientInput(name: "", quantityString: "", unit: .cups)) 
+                            .onChange(of: $ingredient.name) {
+                                if index == ingredients.count - 1 && !$ingredient.name.isEmpty {
+                                    withAnimation {
+                                        ingredients.append(IngredientInput(name: "", quantityString: "", unit: .cups))
                                     }
-                                } else if ingredients[index].name.isEmpty && index != ingredients.count - 1 {
+                                } else if $ingredient.name.isEmpty && index != ingredients.count - 1 {
                                     scheduleCleanup()
                                 }
                             }

--- a/Cauldron/Views/AddRecipe/InstructionsSection.swift
+++ b/Cauldron/Views/AddRecipe/InstructionsSection.swift
@@ -50,9 +50,9 @@ struct InstructionsSection: View {
             // Items container
             ZStack(alignment: .top) {
                 VStack(spacing: isEditMode ? 5 : 10) {
-                    ForEach(instructions.indices, id: \.self) { index in
+                    ForEach(Array($instructions.enumerated()), id: \.[1].id) { index, $instruction in
                         if isEditMode {
-                            let item = instructions[index]
+                            let item = $instruction.wrappedValue
                             let isLastPlaceholder = index == instructions.count - 1 && (item.value.isEmpty || item.isPlaceholder)
                             
                             HStack(alignment: .center) {
@@ -66,16 +66,16 @@ struct InstructionsSection: View {
                                 
                                 // Use direct binding to ensure changes are saved
                                 InstructionInputRow(
-                                    instruction: $instructions[index].value,
+                                    instruction: $instruction.value,
                                     stepNumber: index + 1,
                                     isFocused: Binding(
-                                        get: { 
-                                            focusedIndex == instructions[index].id
+                                        get: {
+                                            focusedIndex == $instruction.id
                                         },
                                         set: { newValue in
                                             if newValue {
-                                                focusedIndex = instructions[index].id
-                                            } else if focusedIndex == instructions[index].id {
+                                                focusedIndex = $instruction.id
+                                            } else if focusedIndex == $instruction.id {
                                                 focusedIndex = nil
                                             }
                                         }
@@ -90,9 +90,9 @@ struct InstructionsSection: View {
                                     .opacity(isLastPlaceholder ? 0.3 : 1)
                                     .onTapGesture {
                                         if !isLastPlaceholder && instructions.count > 1 {
-                                            withAnimation { 
+                                            withAnimation {
                                                 instructions.remove(at: index)
-                                                cleanupEmptyRows() 
+                                                cleanupEmptyRows()
                                             }
                                         }
                                     }
@@ -173,30 +173,30 @@ struct InstructionsSection: View {
                             )
                         } else {
                             InstructionInputRow(
-                                instruction: $instructions[index].value,
+                                instruction: $instruction.value,
                                 stepNumber: index + 1,
                                 isFocused: Binding(
-                                    get: { 
-                                        focusedIndex == instructions[index].id
+                                    get: {
+                                        focusedIndex == $instruction.id
                                     },
                                     set: { newValue in
                                         if newValue {
-                                            focusedIndex = instructions[index].id
-                                        } else if focusedIndex == instructions[index].id {
+                                            focusedIndex = $instruction.id
+                                        } else if focusedIndex == $instruction.id {
                                             focusedIndex = nil
                                         }
                                     }
                                 )
                             )
-                            .onChange(of: focusedIndex == instructions[index].id) {
-                                if focusedIndex == instructions[index].id { checkAndAddPlaceholder() }
+                            .onChange(of: focusedIndex == $instruction.id) {
+                                if focusedIndex == $instruction.id { checkAndAddPlaceholder() }
                             }
-                            .onChange(of: instructions[index].value) {
-                                if index == instructions.count - 1 && !instructions[index].value.isEmpty {
-                                    withAnimation { 
+                            .onChange(of: $instruction.value) {
+                                if index == instructions.count - 1 && !$instruction.value.isEmpty {
+                                    withAnimation {
                                         instructions.append(StringInput(value: "", isPlaceholder: false))
                                     }
-                                } else if instructions[index].value.isEmpty && index != instructions.count - 1 {
+                                } else if $instruction.value.isEmpty && index != instructions.count - 1 {
                                     scheduleCleanup()
                                 }
                             }


### PR DESCRIPTION
## Summary
- use item IDs instead of indices in IngredientsSection and InstructionsSection
- update bindings to the new item-based loops

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683fb8161cdc832eb17255301059a18d