### PR TITLE
Fix favorite toggle preserving recipe metadata

### DIFF
--- a/Cauldron/Core/Models/Recipe.swift
+++ b/Cauldron/Core/Models/Recipe.swift
@@ -157,6 +157,35 @@ struct Recipe: Codable, Sendable, Hashable, Identifiable {
         )
     }
 
+    /// Create a copy with updated favorite flag
+    func withFavorite(_ isFavorite: Bool) -> Recipe {
+        Recipe(
+            id: id,
+            title: title,
+            ingredients: ingredients,
+            steps: steps,
+            yields: yields,
+            totalMinutes: totalMinutes,
+            tags: tags,
+            nutrition: nutrition,
+            sourceURL: sourceURL,
+            sourceTitle: sourceTitle,
+            notes: notes,
+            imageURL: imageURL,
+            isFavorite: isFavorite,
+            visibility: visibility,
+            ownerId: ownerId,
+            cloudRecordName: cloudRecordName,
+            createdAt: createdAt,
+            updatedAt: Date()
+        )
+    }
+
+    /// Toggle the favorite status while preserving metadata
+    func toggledFavorite() -> Recipe {
+        withFavorite(!isFavorite)
+    }
+
     /// Check if the current user owns this recipe
     @MainActor
     func isOwnedByCurrentUser() -> Bool {

--- a/Cauldron/Features/Cook/AllRecipesListView.swift
+++ b/Cauldron/Features/Cook/AllRecipesListView.swift
@@ -126,25 +126,7 @@ struct AllRecipesListView: View {
                             try? await dependencies.recipeRepository.toggleFavorite(id: recipe.id)
                             // Update the local recipe in the list
                             if let index = localRecipes.firstIndex(where: { $0.id == recipe.id }) {
-                                var updatedRecipe = localRecipes[index]
-                                updatedRecipe = Recipe(
-                                    id: updatedRecipe.id,
-                                    title: updatedRecipe.title,
-                                    ingredients: updatedRecipe.ingredients,
-                                    steps: updatedRecipe.steps,
-                                    yields: updatedRecipe.yields,
-                                    totalMinutes: updatedRecipe.totalMinutes,
-                                    tags: updatedRecipe.tags,
-                                    nutrition: updatedRecipe.nutrition,
-                                    sourceURL: updatedRecipe.sourceURL,
-                                    sourceTitle: updatedRecipe.sourceTitle,
-                                    notes: updatedRecipe.notes,
-                                    imageURL: updatedRecipe.imageURL,
-                                    isFavorite: !updatedRecipe.isFavorite,
-                                    createdAt: updatedRecipe.createdAt,
-                                    updatedAt: updatedRecipe.updatedAt
-                                )
-                                localRecipes[index] = updatedRecipe
+                                localRecipes[index] = localRecipes[index].toggledFavorite()
                             }
                         }
                     } label: {


### PR DESCRIPTION
## Summary
- add helper APIs on `Recipe` to copy values while updating the favorite flag
- update the all recipes list to use the helper so metadata like visibility/owner id is preserved when toggling

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f8fd19fb54832e9ee5bac3859ab87a