### PR TITLE
Add iPad App!

### DIFF
--- a/Cauldron.xcodeproj/project.pbxproj
+++ b/Cauldron.xcodeproj/project.pbxproj
@@ -561,7 +561,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -578,7 +578,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -604,7 +604,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -621,7 +621,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Cauldron/App/MainTabView.swift
+++ b/Cauldron/App/MainTabView.swift
@@ -213,6 +213,24 @@ struct MainTabView: View {
                 CookTabView(dependencies: dependencies, preloadedData: preloadedData)
             }
 
+            Tab("Groceries", systemImage: "cart.fill", value: .groceries) {
+                GroceriesView(dependencies: dependencies)
+            }
+
+            Tab("Friends", systemImage: "person.2.fill", value: .sharing) {
+                FriendsTabView(dependencies: dependencies)
+            }
+            .badge(connectionManager.pendingRequestsCount)
+
+            if isRegularWidthLayout {
+                Tab("Collections", systemImage: "folder.fill", value: .collections) {
+                    NavigationStack {
+                        CollectionsListView(dependencies: dependencies)
+                    }
+                }
+                .defaultVisibility(.hidden, for: .sidebar)
+            }
+
             if isRegularWidthLayout {
                 if !featuredSidebarCollections.isEmpty {
                     TabSection {
@@ -230,17 +248,9 @@ struct MainTabView: View {
                     } header: {
                         Text("Collections")
                     }
+                    .defaultVisibility(.hidden, for: .tabBar)
                 }
             }
-
-            Tab("Groceries", systemImage: "cart.fill", value: .groceries) {
-                GroceriesView(dependencies: dependencies)
-            }
-
-            Tab("Friends", systemImage: "person.2.fill", value: .sharing) {
-                FriendsTabView(dependencies: dependencies)
-            }
-            .badge(connectionManager.pendingRequestsCount)
 
             Tab("Search", systemImage: "magnifyingglass", value: .search, role: .search) {
                 SearchTabView(dependencies: dependencies, navigationPath: $searchNavigationPath)
@@ -343,10 +353,6 @@ struct MainTabView: View {
             }
 
             sidebarCollections = ownedCollections.sorted { $0.updatedAt > $1.updatedAt }
-
-            if selectedTab == .collections {
-                selectedTab = .cook
-            }
 
             if case let .collection(collectionID) = selectedTab,
                !sidebarCollections.contains(where: { $0.id == collectionID }) {

--- a/Cauldron/Core/Components/RecipeCardView.swift
+++ b/Cauldron/Core/Components/RecipeCardView.swift
@@ -26,6 +26,8 @@ import SwiftUI
 /// RecipeCardView(sharedRecipe: sharedRecipe, creatorTier: tier, dependencies: deps)
 /// ```
 struct RecipeCardView: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     let recipe: Recipe
     let dependencies: DependencyContainer
     var sharedBy: User?
@@ -78,12 +80,24 @@ struct RecipeCardView: View {
         sharedBy != nil
     }
 
+    private var cardWidth: CGFloat {
+        horizontalSizeClass == .regular ? 252 : 240
+    }
+
+    private var cardHeight: CGFloat {
+        horizontalSizeClass == .regular ? 168 : 160
+    }
+
+    private var metadataTagMaxWidth: CGFloat {
+        horizontalSizeClass == .regular ? 120 : 100
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             // Image with contextual overlays
             ZStack {
                 RecipeImageView(recipe: recipe, recipeImageService: dependencies.recipeImageService)
-                    .frame(width: 240, height: 160)
+                    .frame(width: cardWidth, height: cardHeight)
 
                 if isSharedRecipe {
                     // Shared recipe: show creator overlay
@@ -93,18 +107,18 @@ struct RecipeCardView: View {
                     ownRecipeOverlay
                 }
             }
-            .frame(width: 240, height: 160)
+            .frame(width: cardWidth, height: cardHeight)
 
             // Title - single line for clean look
             Text(recipe.title)
                 .font(.headline)
                 .lineLimit(1)
-                .frame(width: 240, height: 20, alignment: .leading)
+                .frame(width: cardWidth, height: 20, alignment: .leading)
 
             // Metadata row - time and tag
             metadataRow
         }
-        .frame(width: 240)
+        .frame(width: cardWidth)
     }
 
     // MARK: - Overlay Views
@@ -187,7 +201,7 @@ struct RecipeCardView: View {
             if let firstTag = recipe.tags.first {
                 TagView(firstTag)
                     .scaleEffect(0.9)
-                    .frame(maxWidth: 100, alignment: .trailing)
+                    .frame(maxWidth: metadataTagMaxWidth, alignment: .trailing)
                     .onTapGesture {
                         onTagTap?(firstTag)
                     }
@@ -197,7 +211,7 @@ struct RecipeCardView: View {
                     .frame(width: 60)
             }
         }
-        .frame(width: 240, height: 20)
+        .frame(width: cardWidth, height: 20)
     }
 }
 

--- a/Cauldron/Core/Components/RecipeLayoutControls.swift
+++ b/Cauldron/Core/Components/RecipeLayoutControls.swift
@@ -1,0 +1,67 @@
+//
+//  RecipeLayoutControls.swift
+//  Cauldron
+//
+
+import SwiftUI
+
+enum RecipeLayoutMode: String {
+    case auto
+    case compact
+    case grid
+
+    static let appStorageKey = "recipes.layoutMode"
+
+    func resolved(for horizontalSizeClass: UserInterfaceSizeClass?) -> RecipeLayoutMode {
+        if self == .auto {
+            return horizontalSizeClass == .regular ? .grid : .compact
+        }
+        return self
+    }
+
+    var iconName: String {
+        switch self {
+        case .grid:
+            "square.grid.2x2"
+        case .compact, .auto:
+            "list.bullet"
+        }
+    }
+
+    static var defaultGridColumns: [GridItem] {
+        [GridItem(.adaptive(minimum: 240, maximum: 280), spacing: 16)]
+    }
+}
+
+struct RecipeLayoutToolbarButton: View {
+    let resolvedMode: RecipeLayoutMode
+    let onSelectMode: (RecipeLayoutMode) -> Void
+
+    var body: some View {
+        Menu {
+            Button {
+                onSelectMode(.grid)
+            } label: {
+                HStack {
+                    Label("Grid", systemImage: "square.grid.2x2")
+                    if resolvedMode == .grid {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+
+            Button {
+                onSelectMode(.compact)
+            } label: {
+                HStack {
+                    Label("Compact", systemImage: "list.bullet")
+                    if resolvedMode == .compact {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: resolvedMode.iconName)
+        }
+    }
+}

--- a/Cauldron/Core/Extensions/Notification+Names.swift
+++ b/Cauldron/Core/Extensions/Notification+Names.swift
@@ -19,6 +19,9 @@ extension Notification.Name {
     /// Posted when recipe import URL arrives from Share Extension handoff
     static let openRecipeImportURL = Notification.Name("OpenRecipeImportURL")
 
+    /// Posted when a referral invite link is opened and a code is extracted
+    static let openReferralInvite = Notification.Name("OpenReferralInvite")
+
     // MARK: - CloudKit Share Notifications
 
     /// Posted when a CloudKit share should be accepted

--- a/Cauldron/Core/Models/Collection.swift
+++ b/Cauldron/Core/Models/Collection.swift
@@ -17,7 +17,7 @@ import Foundation
 /// - Can contain both owned recipes and referenced recipes
 /// - Support visibility levels (private/public) for sharing
 /// - Stored in CloudKit PUBLIC database to enable sharing
-/// - Custom presentation with emoji/color theme
+/// - Custom presentation with symbol/color theme
 ///
 /// Collections follow the same sharing pattern as recipes:
 /// - Private collections: only visible to owner
@@ -33,7 +33,8 @@ struct Collection: Codable, Sendable, Hashable, Identifiable {
     let visibility: RecipeVisibility
 
     // Presentation metadata
-    let emoji: String?  // Optional emoji icon (e.g., "🎄", "⚡")
+    let emoji: String?  // Legacy optional emoji icon
+    let symbolName: String?  // Optional SF Symbol for navigation/sidebar icon
     let color: String?  // Optional hex color (e.g., "#FF5733")
     let coverImageType: CoverImageType  // How to display the collection card
     let coverImageURL: URL?  // Local file URL for custom cover image
@@ -55,7 +56,8 @@ struct Collection: Codable, Sendable, Hashable, Identifiable {
         recipeIds: [UUID] = [],
         visibility: RecipeVisibility = .publicRecipe,
         emoji: String? = nil,
-        color: String? = nil,
+        symbolName: String? = "folder.fill",
+        color: String? = "#FF9933",
         coverImageType: CoverImageType = .recipeGrid,
         coverImageURL: URL? = nil,
         cloudCoverImageRecordName: String? = nil,
@@ -71,6 +73,7 @@ struct Collection: Codable, Sendable, Hashable, Identifiable {
         self.recipeIds = recipeIds
         self.visibility = visibility
         self.emoji = emoji
+        self.symbolName = symbolName
         self.color = color
         self.coverImageType = coverImageType
         self.coverImageURL = coverImageURL
@@ -97,6 +100,7 @@ struct Collection: Codable, Sendable, Hashable, Identifiable {
         recipeIds: [UUID]? = nil,
         visibility: RecipeVisibility? = nil,
         emoji: String? = nil,
+        symbolName: String? = nil,
         color: String? = nil,
         coverImageType: CoverImageType? = nil,
         coverImageURL: URL? = nil,
@@ -111,6 +115,7 @@ struct Collection: Codable, Sendable, Hashable, Identifiable {
             recipeIds: recipeIds ?? self.recipeIds,
             visibility: visibility ?? self.visibility,
             emoji: emoji ?? self.emoji,
+            symbolName: symbolName ?? self.symbolName,
             color: color ?? self.color,
             coverImageType: coverImageType ?? self.coverImageType,
             coverImageURL: coverImageURL ?? self.coverImageURL,

--- a/Cauldron/Core/Models/Collection.swift
+++ b/Cauldron/Core/Models/Collection.swift
@@ -105,7 +105,8 @@ struct Collection: Codable, Sendable, Hashable, Identifiable {
         coverImageType: CoverImageType? = nil,
         coverImageURL: URL? = nil,
         cloudCoverImageRecordName: String? = nil,
-        coverImageModifiedAt: Date? = nil
+        coverImageModifiedAt: Date? = nil,
+        clearCoverImageMetadata: Bool = false
     ) -> Collection {
         Collection(
             id: self.id,
@@ -118,9 +119,9 @@ struct Collection: Codable, Sendable, Hashable, Identifiable {
             symbolName: symbolName ?? self.symbolName,
             color: color ?? self.color,
             coverImageType: coverImageType ?? self.coverImageType,
-            coverImageURL: coverImageURL ?? self.coverImageURL,
-            cloudCoverImageRecordName: cloudCoverImageRecordName ?? self.cloudCoverImageRecordName,
-            coverImageModifiedAt: coverImageModifiedAt ?? self.coverImageModifiedAt,
+            coverImageURL: clearCoverImageMetadata ? nil : (coverImageURL ?? self.coverImageURL),
+            cloudCoverImageRecordName: clearCoverImageMetadata ? nil : (cloudCoverImageRecordName ?? self.cloudCoverImageRecordName),
+            coverImageModifiedAt: clearCoverImageMetadata ? nil : (coverImageModifiedAt ?? self.coverImageModifiedAt),
             cloudRecordName: self.cloudRecordName,
             createdAt: self.createdAt,
             updatedAt: Date()

--- a/Cauldron/Core/Persistence/CollectionModel.swift
+++ b/Cauldron/Core/Persistence/CollectionModel.swift
@@ -23,6 +23,7 @@ final class CollectionModel {
 
     // Presentation
     var emoji: String?
+    var symbolName: String?
     var color: String?
     var coverImageType: String = "recipeGrid"  // CoverImageType rawValue
     var coverImagePath: String?  // Store URL path as string for SwiftData
@@ -42,6 +43,7 @@ final class CollectionModel {
         userId: UUID,
         recipeIdsBlob: Data = Data(),
         emoji: String? = nil,
+        symbolName: String? = nil,
         color: String? = nil,
         coverImageType: String = "recipeGrid",
         coverImagePath: String? = nil,
@@ -58,6 +60,7 @@ final class CollectionModel {
         self.userId = userId
         self.recipeIdsBlob = recipeIdsBlob
         self.emoji = emoji
+        self.symbolName = symbolName
         self.color = color
         self.coverImageType = coverImageType
         self.coverImagePath = coverImagePath
@@ -81,6 +84,7 @@ final class CollectionModel {
             userId: collection.userId,
             recipeIdsBlob: recipeIdsData,
             emoji: collection.emoji,
+            symbolName: collection.symbolName,
             color: collection.color,
             coverImageType: collection.coverImageType.rawValue,
             coverImagePath: collection.coverImageURL?.absoluteString,
@@ -106,6 +110,7 @@ final class CollectionModel {
             recipeIds: recipeIds,
             visibility: RecipeVisibility(rawValue: visibility) ?? .privateRecipe,
             emoji: emoji,
+            symbolName: symbolName,
             color: color,
             coverImageType: CoverImageType(rawValue: coverImageType) ?? .recipeGrid,
             coverImageURL: coverImagePath.flatMap { URL(string: $0) },

--- a/Cauldron/Features/Collections/CollectionCardView.swift
+++ b/Cauldron/Features/Collections/CollectionCardView.swift
@@ -10,131 +10,70 @@ import SwiftUI
 struct CollectionCardView: View {
     let collection: Collection
     let recipeImages: [URL?]  // Up to 4 recipe image URLs for the grid
-    let dependencies: DependencyContainer?
+    let preferredWidth: CGFloat?
 
-    @State private var customCoverImage: UIImage?
-    @State private var isLoadingImage = false
-
-    init(collection: Collection, recipeImages: [URL?], dependencies: DependencyContainer? = nil) {
+    init(collection: Collection, recipeImages: [URL?], preferredWidth: CGFloat? = 200) {
         self.collection = collection
         self.recipeImages = recipeImages
-        self.dependencies = dependencies
+        self.preferredWidth = preferredWidth
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Cover image/grid
-            ZStack {
-                switch collection.coverImageType {
-                case .customImage:
-                    customImageView
-                        .frame(width: 160, height: 160)
-                case .emoji:
-                    // Show emoji with color background
-                    if let emoji = collection.emoji {
-                        collectionColor
-                            .frame(width: 160, height: 160)
-                            .overlay(
-                                Text(emoji)
-                                    .font(.system(size: 60))
-                            )
-                    } else {
-                        // Fallback to grid if emoji not set
-                        recipeGridView
-                            .frame(width: 160, height: 160)
-                    }
-                case .color:
-                    // Show solid color with folder icon and name
-                    collectionColor
-                        .frame(width: 160, height: 160)
-                        .overlay(
-                            VStack(spacing: 4) {
-                                Image(systemName: "folder.fill")
-                                    .font(.system(size: 40))
-                                    .foregroundColor(.white.opacity(0.8))
-                                Text(collection.name)
-                                    .font(.caption)
-                                    .fontWeight(.medium)
-                                    .foregroundColor(.white)
-                                    .lineLimit(2)
-                                    .multilineTextAlignment(.center)
-                                    .padding(.horizontal, 8)
-                            }
-                        )
-                case .recipeGrid:
-                    // Default: Show 2x2 grid of recipe images
-                    recipeGridView
-                        .frame(width: 160, height: 160)
-                }
-            }
-            .cornerRadius(12)
-            .clipped()
-            .task {
-                if collection.coverImageType == .customImage {
-                    await loadCustomImage()
-                }
-            }
+        VStack(alignment: .leading, spacing: 8) {
+            recipeGridView
+            .aspectRatio(1, contentMode: .fit)
+            .clipShape(.rect(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(collectionColor.opacity(0.2), lineWidth: 1)
+            )
 
-            // Collection name and count
             VStack(alignment: .leading, spacing: 4) {
-                Text(collection.name)
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Image(systemName: collectionSymbolName)
+                        .font(.subheadline)
+                        .foregroundStyle(collectionColor)
+
+                    Text(collection.name)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .lineLimit(1)
+                }
 
                 Text("\(collection.recipeCount) recipe\(collection.recipeCount == 1 ? "" : "s")")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
-            .frame(width: 160, alignment: .leading)
-            .padding(.top, 8)
         }
-        .frame(width: 160)
+        .frame(width: preferredWidth, alignment: .leading)
+        .frame(maxWidth: preferredWidth == nil ? .infinity : nil, alignment: .leading)
     }
 
-    // MARK: - Recipe Grid View
-
     private var recipeGridView: some View {
-        Group {
-            let size: CGFloat = 80  // 160 / 2 for the 2x2 grid
+        GeometryReader { proxy in
+            let tileSize = proxy.size.width / 2
 
-            // Show empty state if collection has no recipes, not based on loaded images
-            if collection.recipeCount == 0 {
-                // Empty state - show placeholder
+            if collection.recipeCount == 0 || recipeImages.isEmpty || recipeImages.allSatisfy({ $0 == nil }) {
                 collectionColor
                     .overlay(
-                        VStack(spacing: 8) {
-                            Image(systemName: "photo.stack")
-                                .font(.system(size: 30))
-                                .foregroundColor(.white.opacity(0.6))
-                            Text("No recipes")
+                        VStack(spacing: 6) {
+                            Image(systemName: collectionSymbolName)
+                                .font(.system(size: 28))
+                                .foregroundStyle(.white.opacity(0.7))
+                            Text(collection.recipeCount == 0 ? "No recipes" : "\(collection.recipeCount) recipe\(collection.recipeCount == 1 ? "" : "s")")
                                 .font(.caption)
-                                .foregroundColor(.white.opacity(0.8))
-                        }
-                    )
-            } else if recipeImages.isEmpty || recipeImages.allSatisfy({ $0 == nil }) {
-                // Has recipes but images not loaded - show placeholder with count
-                collectionColor
-                    .overlay(
-                        VStack(spacing: 8) {
-                            Image(systemName: "photo.stack")
-                                .font(.system(size: 30))
-                                .foregroundColor(.white.opacity(0.6))
-                            Text("\(collection.recipeCount) recipe\(collection.recipeCount == 1 ? "" : "s")")
-                                .font(.caption)
-                                .foregroundColor(.white.opacity(0.8))
+                                .foregroundStyle(.white.opacity(0.85))
                         }
                     )
             } else {
-                // Show 2x2 grid of recipe images
                 VStack(spacing: 0) {
                     HStack(spacing: 0) {
-                        recipeImageTile(at: 0, size: size)
-                        recipeImageTile(at: 1, size: size)
+                        recipeImageTile(at: 0, size: tileSize)
+                        recipeImageTile(at: 1, size: tileSize)
                     }
                     HStack(spacing: 0) {
-                        recipeImageTile(at: 2, size: size)
-                        recipeImageTile(at: 3, size: size)
+                        recipeImageTile(at: 2, size: tileSize)
+                        recipeImageTile(at: 3, size: tileSize)
                     }
                 }
             }
@@ -173,78 +112,18 @@ struct CollectionCardView: View {
             .overlay(
                 Image(systemName: "fork.knife")
                     .font(.system(size: size * 0.3))
-                    .foregroundColor(.white.opacity(0.5))
+                    .foregroundStyle(.white.opacity(0.5))
             )
     }
-
-    // MARK: - Custom Image View
-
-    private var customImageView: some View {
-        Group {
-            if let customCoverImage = customCoverImage {
-                Image(uiImage: customCoverImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-            } else if isLoadingImage {
-                collectionColor
-                    .overlay(
-                        ProgressView()
-                            .tint(.white)
-                    )
-            } else {
-                // Fallback to recipe grid if custom image fails to load
-                recipeGridView
-            }
-        }
-    }
-
-    @MainActor
-    private func loadCustomImage() async {
-        guard !isLoadingImage else { return }
-        isLoadingImage = true
-        defer { isLoadingImage = false }
-
-        let loader = dependencies?.entityImageLoader ?? EntityImageLoader.shared
-        if let image = await loader.loadCollectionCoverImage(for: collection, dependencies: dependencies) {
-            if let currentImage = customCoverImage {
-                if !areImagesEqual(image, currentImage) {
-                    customCoverImage = image
-                }
-            } else {
-                customCoverImage = image
-            }
-        }
-    }
-
-    /// Compare two images to see if they're visually identical
-    /// This prevents UI updates when CloudKit sync returns the same image
-    private func areImagesEqual(_ image1: UIImage, _ image2: UIImage) -> Bool {
-        // Fast path: if they're literally the same object, they're equal
-        if image1 === image2 {
-            return true
-        }
-
-        // Compare image dimensions
-        if image1.size != image2.size {
-            return false
-        }
-
-        // Compare scale
-        if image1.scale != image2.scale {
-            return false
-        }
-
-        // If dimensions and scale match, assume they're the same image
-        // This prevents expensive byte-by-byte comparison
-        return true
-    }
-
-    // MARK: - Color
 
     private var collectionColor: Color {
         if let colorHex = collection.color {
             return Color(hex: colorHex) ?? .cauldronOrange
         }
         return .cauldronOrange
+    }
+
+    private var collectionSymbolName: String {
+        collection.symbolName ?? "folder.fill"
     }
 }

--- a/Cauldron/Features/Collections/CollectionDetailView.swift
+++ b/Cauldron/Features/Collections/CollectionDetailView.swift
@@ -9,20 +9,6 @@ import SwiftUI
 import os
 
 struct CollectionDetailView: View {
-    private enum RecipeLayoutMode: String, CaseIterable {
-        case auto
-        case compact
-        case grid
-
-        var title: String {
-            switch self {
-            case .auto: "Auto"
-            case .compact: "Compact"
-            case .grid: "Grid"
-            }
-        }
-    }
-
     let initialCollection: Collection
     let dependencies: DependencyContainer
 
@@ -36,7 +22,7 @@ struct CollectionDetailView: View {
     @State private var recipeImages: [URL?] = []  // For recipe grid display
     @Environment(\.dismiss) private var dismiss
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @AppStorage("recipes.layoutMode") private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
+    @AppStorage(RecipeLayoutMode.appStorageKey) private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
 
     // External sharing
     @State private var showShareSheet = false
@@ -88,10 +74,7 @@ struct CollectionDetailView: View {
 
     private var resolvedRecipeLayoutMode: RecipeLayoutMode {
         let storedMode = RecipeLayoutMode(rawValue: storedRecipeLayoutMode) ?? .auto
-        if storedMode == .auto {
-            return horizontalSizeClass == .regular ? .grid : .compact
-        }
-        return storedMode
+        return storedMode.resolved(for: horizontalSizeClass)
     }
 
     private var usesGridRecipeLayout: Bool {
@@ -99,30 +82,8 @@ struct CollectionDetailView: View {
     }
 
     private var recipeLayoutToolbarMenu: some View {
-        Menu {
-            Button {
-                storedRecipeLayoutMode = RecipeLayoutMode.grid.rawValue
-            } label: {
-                HStack {
-                    Label("Grid", systemImage: "square.grid.2x2")
-                    if resolvedRecipeLayoutMode == .grid {
-                        Image(systemName: "checkmark")
-                    }
-                }
-            }
-
-            Button {
-                storedRecipeLayoutMode = RecipeLayoutMode.compact.rawValue
-            } label: {
-                HStack {
-                    Label("Compact", systemImage: "list.bullet")
-                    if resolvedRecipeLayoutMode == .compact {
-                        Image(systemName: "checkmark")
-                    }
-                }
-            }
-        } label: {
-            Image(systemName: resolvedRecipeLayoutMode == .grid ? "square.grid.2x2" : "list.bullet")
+        RecipeLayoutToolbarButton(resolvedMode: resolvedRecipeLayoutMode) { mode in
+            storedRecipeLayoutMode = mode.rawValue
         }
     }
 

--- a/Cauldron/Features/Collections/CollectionFormView.swift
+++ b/Cauldron/Features/Collections/CollectionFormView.swift
@@ -311,9 +311,7 @@ struct CollectionFormView: View {
                     symbolName: resolvedSymbolName,
                     color: resolvedColor,
                     coverImageType: .recipeGrid,
-                    coverImageURL: nil,
-                    cloudCoverImageRecordName: nil,
-                    coverImageModifiedAt: nil
+                    clearCoverImageMetadata: true
                 )
                 try await dependencies.collectionRepository.update(updated)
                 AppLogger.general.info("✅ Updated collection: \(trimmedName)")

--- a/Cauldron/Features/Collections/CollectionsListView.swift
+++ b/Cauldron/Features/Collections/CollectionsListView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct CollectionsListView: View {
     @Environment(\.dependencies) private var dependencies
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var viewModel: CollectionsListViewModel
     @State private var showingCreateSheet = false
     @State private var recipeImageCache: [UUID: [URL?]] = [:]  // Cache recipe images by collection ID
@@ -19,20 +20,17 @@ struct CollectionsListView: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 24) {
+            VStack(spacing: 16) {
                 // My Collections Section
                 if !viewModel.filteredOwnedCollections.isEmpty {
                     VStack(alignment: .leading, spacing: 12) {
-                        LazyVGrid(columns: [
-                            GridItem(.flexible(), spacing: 16),
-                            GridItem(.flexible(), spacing: 16)
-                        ], spacing: 20) {
+                        LazyVGrid(columns: gridColumns, spacing: 12) {
                             ForEach(viewModel.filteredOwnedCollections) { collection in
                                 NavigationLink(destination: CollectionDetailView(collection: collection, dependencies: dependencies)) {
                                     CollectionCardView(
                                         collection: collection,
                                         recipeImages: recipeImageCache[collection.id] ?? [],
-                                        dependencies: dependencies
+                                        preferredWidth: nil
                                     )
                                 }
                                 .buttonStyle(PlainButtonStyle())
@@ -128,6 +126,16 @@ struct CollectionsListView: View {
                 await viewModel.loadCollections()
             }
         }
+    }
+
+    private var gridColumns: [GridItem] {
+        if horizontalSizeClass == .regular {
+            return [GridItem(.adaptive(minimum: 190, maximum: 240), spacing: 12)]
+        }
+        return [
+            GridItem(.flexible(minimum: 150), spacing: 12),
+            GridItem(.flexible(minimum: 150), spacing: 12)
+        ]
     }
 }
 

--- a/Cauldron/Features/Cook/AllRecipesListView.swift
+++ b/Cauldron/Features/Cook/AllRecipesListView.swift
@@ -10,9 +10,16 @@ import os
 
 /// Full list view for all recipes with filtering options
 struct AllRecipesListView: View {
+    private enum RecipeLayoutMode: String {
+        case auto
+        case compact
+        case grid
+    }
+
     let recipes: [Recipe]
     let dependencies: DependencyContainer
     
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var searchText = ""
     @State private var selectedTag: String?
     @State private var sortOption: SortOption = .recent
@@ -22,6 +29,7 @@ struct AllRecipesListView: View {
     @State private var showingAIGenerator = false
     @State private var showingCollectionForm = false
     @State private var selectedRecipe: Recipe?
+    @AppStorage("recipes.layoutMode") private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
     
     init(recipes: [Recipe], dependencies: DependencyContainer) {
         self.recipes = recipes
@@ -84,9 +92,21 @@ struct AllRecipesListView: View {
         
         return filtered
     }
+
+    private var resolvedRecipeLayoutMode: RecipeLayoutMode {
+        let storedMode = RecipeLayoutMode(rawValue: storedRecipeLayoutMode) ?? .auto
+        if storedMode == .auto {
+            return horizontalSizeClass == .regular ? .grid : .compact
+        }
+        return storedMode
+    }
+
+    private var usesGridRecipeLayout: Bool {
+        resolvedRecipeLayoutMode == .grid
+    }
     
     var body: some View {
-        listContent
+        contentView
             .navigationTitle("All Recipes")
             .navigationBarTitleDisplayMode(.large)
             .searchable(text: $searchText, prompt: "Search recipes")
@@ -100,35 +120,65 @@ struct AllRecipesListView: View {
             .toolbar { toolbarContent }
     }
 
-    private var listContent: some View {
-        List {
-            activeFiltersSection
-            recipesForEach
+    @ViewBuilder
+    private var contentView: some View {
+        if usesGridRecipeLayout {
+            gridContent
+        } else {
+            listContent
         }
     }
 
-    @ViewBuilder
-    private var activeFiltersSection: some View {
-        if let tag = selectedTag {
-            Section {
-                HStack {
-                    Text("Tag: \(tag)")
-                        .font(.caption)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(Color.cauldronOrange.opacity(0.2))
-                        .cornerRadius(6)
-                    Spacer()
-                    Button("Clear") { selectedTag = nil }
-                        .font(.caption)
+    private var listContent: some View {
+        List {
+            if let tag = selectedTag {
+                Section {
+                    activeTagChip(tag: tag)
                 }
+            }
+
+            ForEach(filteredAndSortedRecipes) { recipe in
+                recipeRow(for: recipe)
             }
         }
     }
 
-    private var recipesForEach: some View {
-        ForEach(filteredAndSortedRecipes) { recipe in
-            recipeRow(for: recipe)
+    private var gridContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                if let tag = selectedTag {
+                    activeTagChip(tag: tag)
+                }
+
+                LazyVGrid(columns: recipeGridColumns, spacing: 16) {
+                    ForEach(filteredAndSortedRecipes) { recipe in
+                        NavigationLink(destination: RecipeDetailView(recipe: recipe, dependencies: dependencies)) {
+                            RecipeCardView(recipe: recipe, dependencies: dependencies)
+                        }
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            deleteButton(for: recipe)
+                            favoriteButton(for: recipe)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
+    }
+
+    private func activeTagChip(tag: String) -> some View {
+        HStack {
+            Text("Tag: \(tag)")
+                .font(.caption)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.cauldronOrange.opacity(0.2))
+                .cornerRadius(6)
+            Spacer()
+            Button("Clear") { selectedTag = nil }
+                .font(.caption)
         }
     }
 
@@ -163,6 +213,7 @@ struct AllRecipesListView: View {
 
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .navigationBarTrailing) { recipeLayoutMenu }
         ToolbarItem(placement: .navigationBarTrailing) { filterSortMenu }
         ToolbarItem(placement: .navigationBarTrailing) { addRecipeMenu }
     }
@@ -170,6 +221,34 @@ struct AllRecipesListView: View {
     private func handleRecipeDeleted(_ notification: Notification) {
         if let deletedRecipeId = notification.object as? UUID {
             localRecipes.removeAll { $0.id == deletedRecipeId }
+        }
+    }
+
+    private var recipeLayoutMenu: some View {
+        Menu {
+            Button {
+                storedRecipeLayoutMode = RecipeLayoutMode.grid.rawValue
+            } label: {
+                HStack {
+                    Label("Grid", systemImage: "square.grid.2x2")
+                    if resolvedRecipeLayoutMode == .grid {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+
+            Button {
+                storedRecipeLayoutMode = RecipeLayoutMode.compact.rawValue
+            } label: {
+                HStack {
+                    Label("Compact", systemImage: "list.bullet")
+                    if resolvedRecipeLayoutMode == .compact {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: resolvedRecipeLayoutMode == .grid ? "square.grid.2x2" : "list.bullet")
         }
     }
 
@@ -232,6 +311,10 @@ struct AllRecipesListView: View {
             showingImporter: $showingImporter,
             showingCollectionForm: $showingCollectionForm
         )
+    }
+
+    private var recipeGridColumns: [GridItem] {
+        [GridItem(.adaptive(minimum: 240, maximum: 280), spacing: 16)]
     }
     
     private func deleteRecipe(_ recipe: Recipe) async {

--- a/Cauldron/Features/Cook/CategoryRecipesListView.swift
+++ b/Cauldron/Features/Cook/CategoryRecipesListView.swift
@@ -10,14 +10,22 @@ import os
 
 /// Full list view for recipes in a specific category
 struct CategoryRecipesListView: View {
+    private enum RecipeLayoutMode: String {
+        case auto
+        case compact
+        case grid
+    }
+
     let categoryName: String
     let recipes: [Recipe]
     let dependencies: DependencyContainer
     
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var localRecipes: [Recipe]
     @State private var showingImporter = false
     @State private var showingEditor = false
     @State private var selectedRecipe: Recipe?
+    @AppStorage("recipes.layoutMode") private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
     
     init(categoryName: String, recipes: [Recipe], dependencies: DependencyContainer) {
         self.categoryName = categoryName
@@ -25,56 +33,21 @@ struct CategoryRecipesListView: View {
         self.dependencies = dependencies
         self._localRecipes = State(initialValue: recipes)
     }
+
+    private var resolvedRecipeLayoutMode: RecipeLayoutMode {
+        let storedMode = RecipeLayoutMode(rawValue: storedRecipeLayoutMode) ?? .auto
+        if storedMode == .auto {
+            return horizontalSizeClass == .regular ? .grid : .compact
+        }
+        return storedMode
+    }
+
+    private var usesGridRecipeLayout: Bool {
+        resolvedRecipeLayoutMode == .grid
+    }
     
     var body: some View {
-        List {
-            ForEach(localRecipes) { recipe in
-                NavigationLink(destination: RecipeDetailView(recipe: recipe, dependencies: dependencies)) {
-                    RecipeRowView(recipe: recipe, dependencies: dependencies)
-                }
-                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                    Button(role: .destructive) {
-                        Task {
-                            await deleteRecipe(recipe)
-                        }
-                    } label: {
-                        Label("Delete", systemImage: "trash")
-                    }
-                    .tint(.red)
-                    
-                    Button {
-                        Task {
-                            try? await dependencies.recipeRepository.toggleFavorite(id: recipe.id)
-                            // Update the local recipe in the list
-                            if let index = localRecipes.firstIndex(where: { $0.id == recipe.id }) {
-                                var updatedRecipe = localRecipes[index]
-                                updatedRecipe = Recipe(
-                                    id: updatedRecipe.id,
-                                    title: updatedRecipe.title,
-                                    ingredients: updatedRecipe.ingredients,
-                                    steps: updatedRecipe.steps,
-                                    yields: updatedRecipe.yields,
-                                    totalMinutes: updatedRecipe.totalMinutes,
-                                    tags: updatedRecipe.tags,
-                                    nutrition: updatedRecipe.nutrition,
-                                    sourceURL: updatedRecipe.sourceURL,
-                                    sourceTitle: updatedRecipe.sourceTitle,
-                                    notes: updatedRecipe.notes,
-                                    imageURL: updatedRecipe.imageURL,
-                                    isFavorite: !updatedRecipe.isFavorite,
-                                    createdAt: updatedRecipe.createdAt,
-                                    updatedAt: updatedRecipe.updatedAt
-                                )
-                                localRecipes[index] = updatedRecipe
-                            }
-                        }
-                    } label: {
-                        Label(recipe.isFavorite ? "Unfavorite" : "Favorite", systemImage: recipe.isFavorite ? "star.slash" : "star.fill")
-                    }
-                    .tint(.yellow)
-                }
-            }
-        }
+        contentView
         .navigationTitle(categoryName)
         .navigationBarTitleDisplayMode(.large)
         .onAppear {
@@ -108,6 +81,10 @@ struct CategoryRecipesListView: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
+                recipeLayoutMenu
+            }
+
+            ToolbarItem(placement: .navigationBarTrailing) {
                 Menu {
                     Button {
                         showingEditor = true
@@ -126,6 +103,123 @@ struct CategoryRecipesListView: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        if usesGridRecipeLayout {
+            gridContent
+        } else {
+            listContent
+        }
+    }
+
+    private var listContent: some View {
+        List {
+            ForEach(localRecipes) { recipe in
+                NavigationLink(destination: RecipeDetailView(recipe: recipe, dependencies: dependencies)) {
+                    RecipeRowView(recipe: recipe, dependencies: dependencies)
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    deleteButton(for: recipe)
+                    favoriteButton(for: recipe)
+                }
+            }
+        }
+    }
+
+    private var gridContent: some View {
+        ScrollView {
+            LazyVGrid(columns: recipeGridColumns, spacing: 16) {
+                ForEach(localRecipes) { recipe in
+                    NavigationLink(destination: RecipeDetailView(recipe: recipe, dependencies: dependencies)) {
+                        RecipeCardView(recipe: recipe, dependencies: dependencies)
+                    }
+                    .buttonStyle(.plain)
+                    .contextMenu {
+                        deleteButton(for: recipe)
+                        favoriteButton(for: recipe)
+                    }
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
+    }
+
+    private var recipeLayoutMenu: some View {
+        Menu {
+            Button {
+                storedRecipeLayoutMode = RecipeLayoutMode.grid.rawValue
+            } label: {
+                HStack {
+                    Label("Grid", systemImage: "square.grid.2x2")
+                    if resolvedRecipeLayoutMode == .grid {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+
+            Button {
+                storedRecipeLayoutMode = RecipeLayoutMode.compact.rawValue
+            } label: {
+                HStack {
+                    Label("Compact", systemImage: "list.bullet")
+                    if resolvedRecipeLayoutMode == .compact {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: resolvedRecipeLayoutMode == .grid ? "square.grid.2x2" : "list.bullet")
+        }
+    }
+
+    private func deleteButton(for recipe: Recipe) -> some View {
+        Button(role: .destructive) {
+            Task {
+                await deleteRecipe(recipe)
+            }
+        } label: {
+            Label("Delete", systemImage: "trash")
+        }
+        .tint(.red)
+    }
+
+    private func favoriteButton(for recipe: Recipe) -> some View {
+        Button {
+            Task {
+                try? await dependencies.recipeRepository.toggleFavorite(id: recipe.id)
+                if let index = localRecipes.firstIndex(where: { $0.id == recipe.id }) {
+                    var updatedRecipe = localRecipes[index]
+                    updatedRecipe = Recipe(
+                        id: updatedRecipe.id,
+                        title: updatedRecipe.title,
+                        ingredients: updatedRecipe.ingredients,
+                        steps: updatedRecipe.steps,
+                        yields: updatedRecipe.yields,
+                        totalMinutes: updatedRecipe.totalMinutes,
+                        tags: updatedRecipe.tags,
+                        nutrition: updatedRecipe.nutrition,
+                        sourceURL: updatedRecipe.sourceURL,
+                        sourceTitle: updatedRecipe.sourceTitle,
+                        notes: updatedRecipe.notes,
+                        imageURL: updatedRecipe.imageURL,
+                        isFavorite: !updatedRecipe.isFavorite,
+                        createdAt: updatedRecipe.createdAt,
+                        updatedAt: updatedRecipe.updatedAt
+                    )
+                    localRecipes[index] = updatedRecipe
+                }
+            }
+        } label: {
+            Label(recipe.isFavorite ? "Unfavorite" : "Favorite", systemImage: recipe.isFavorite ? "star.slash" : "star.fill")
+        }
+        .tint(.yellow)
+    }
+
+    private var recipeGridColumns: [GridItem] {
+        [GridItem(.adaptive(minimum: 240, maximum: 280), spacing: 16)]
     }
     
     private func deleteRecipe(_ recipe: Recipe) async {

--- a/Cauldron/Features/Cook/CookTabView.swift
+++ b/Cauldron/Features/Cook/CookTabView.swift
@@ -34,80 +34,85 @@ struct CookTabView: View {
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            ScrollViewReader { proxy in
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 24) {
-                        // New User CTA (if no own recipes) - show social content for new users
-                        if viewModel.allRecipes.isEmpty {
-                            newUserCTA
+            cookNavigationContent
+        }
+    }
 
-                            // From Friends (show early for new users)
-                            if !viewModel.friendsRecipes.isEmpty {
-                                friendsRecipesSection
-                            }
+    private var cookNavigationContent: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    // New User CTA (if no own recipes) - show social content for new users
+                    if viewModel.allRecipes.isEmpty {
+                        newUserCTA
 
-                            // Popular in Cauldron (show early for new users)
-                            if !viewModel.popularRecipes.isEmpty {
-                                popularRecipesSection
-                            }
-                        } else {
-                            // User has recipes - show their content first
+                        // From Friends (show early for new users)
+                        if !viewModel.friendsRecipes.isEmpty {
+                            friendsRecipesSection
+                        }
 
-                            if shouldSpotlightRecentlyAdded, !viewModel.recentlyAddedRecipes.isEmpty {
-                                recentlyAddedSection
-                                    .id(recentlyAddedSectionID)
-                            }
+                        // Popular in Cauldron (show early for new users)
+                        if !viewModel.popularRecipes.isEmpty {
+                            popularRecipesSection
+                        }
+                    } else {
+                        // User has recipes - show their content first
 
-                            // Dynamic Tag Rows (Promoted & Standard)
-                            ForEach(viewModel.tagRows, id: \.tag) { tagRow in
-                                tagRowSection(tag: tagRow.tag, recipes: tagRow.recipes)
-                            }
+                        if shouldSpotlightRecentlyAdded, !viewModel.recentlyAddedRecipes.isEmpty {
+                            recentlyAddedSection
+                                .id(recentlyAddedSectionID)
+                        }
 
-                            // Quick & Easy
-                            if !viewModel.quickRecipes.isEmpty {
-                                quickRecipesSection
-                            }
+                        // Dynamic Tag Rows (Promoted & Standard)
+                        ForEach(viewModel.tagRows, id: \.tag) { tagRow in
+                            tagRowSection(tag: tagRow.tag, recipes: tagRow.recipes)
+                        }
 
-                            // On Rotation
-                            if !viewModel.onRotationRecipes.isEmpty {
-                                onRotationSection
-                            }
+                        // Quick & Easy
+                        if !viewModel.quickRecipes.isEmpty {
+                            quickRecipesSection
+                        }
 
-                            // Rediscover Favorites
-                            if !viewModel.forgottenFavorites.isEmpty {
-                                forgottenFavoritesSection
-                            }
+                        // On Rotation
+                        if !viewModel.onRotationRecipes.isEmpty {
+                            onRotationSection
+                        }
 
-                            // My Collections
-                            collectionsSection
+                        // Rediscover Favorites
+                        if !viewModel.forgottenFavorites.isEmpty {
+                            forgottenFavoritesSection
+                        }
 
-                            // Recently Cooked
-                            if !viewModel.recentlyCookedRecipes.isEmpty {
-                                recentlyCookedSection
-                            }
+                        // My Collections
+                        collectionsSection
 
-                            // Favorites
-                            if !viewModel.favoriteRecipes.isEmpty {
-                                favoritesSection
-                            }
+                        // Recently Cooked
+                        if !viewModel.recentlyCookedRecipes.isEmpty {
+                            recentlyCookedSection
+                        }
 
-                            // All Recipes
-                            allRecipesSection
+                        // Favorites
+                        if !viewModel.favoriteRecipes.isEmpty {
+                            favoritesSection
+                        }
 
-                            // Social content at bottom for users with recipes
-                            // From Friends (inspiration section)
-                            if !viewModel.friendsRecipes.isEmpty {
-                                friendsRecipesSection
-                            }
+                        // All Recipes
+                        allRecipesSection
 
-                            // Popular in Cauldron (discovery section)
-                            if !viewModel.popularRecipes.isEmpty {
-                                popularRecipesSection
-                            }
+                        // Social content at bottom for users with recipes
+                        // From Friends (inspiration section)
+                        if !viewModel.friendsRecipes.isEmpty {
+                            friendsRecipesSection
+                        }
+
+                        // Popular in Cauldron (discovery section)
+                        if !viewModel.popularRecipes.isEmpty {
+                            popularRecipesSection
                         }
                     }
-                    .padding(.vertical)
                 }
+                .padding(.vertical)
+            }
             .navigationTitle("Cook")
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -241,7 +246,6 @@ struct CookTabView: View {
             .onDisappear {
                 recentlyAddedSpotlightTask?.cancel()
                 recentlyAddedSpotlightTask = nil
-            }
             }
         }
     }
@@ -407,8 +411,7 @@ struct CookTabView: View {
                             NavigationLink(destination: CollectionDetailView(collection: collection, dependencies: viewModel.dependencies)) {
                                 CollectionCardView(
                                     collection: collection,
-                                    recipeImages: collectionImageCache[collection.id] ?? [],
-                                    dependencies: viewModel.dependencies
+                                    recipeImages: collectionImageCache[collection.id] ?? []
                                 )
                             }
                             .buttonStyle(.plain)

--- a/Cauldron/Features/Cook/FavoritesListView.swift
+++ b/Cauldron/Features/Cook/FavoritesListView.swift
@@ -10,10 +10,18 @@ import os
 
 /// Full list view for favorite recipes
 struct FavoritesListView: View {
+    private enum RecipeLayoutMode: String {
+        case auto
+        case compact
+        case grid
+    }
+
     let recipes: [Recipe]
     let dependencies: DependencyContainer
 
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var localRecipes: [Recipe]
+    @AppStorage("recipes.layoutMode") private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
 
     init(recipes: [Recipe], dependencies: DependencyContainer) {
         self.recipes = recipes
@@ -21,41 +29,20 @@ struct FavoritesListView: View {
         self._localRecipes = State(initialValue: recipes)
     }
 
-    var body: some View {
-        List {
-            Section {
-                Text("Recipes you've marked as favorites")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-            }
-
-            ForEach(localRecipes) { recipe in
-                NavigationLink(destination: RecipeDetailView(recipe: recipe, dependencies: dependencies)) {
-                    RecipeRowView(recipe: recipe, dependencies: dependencies)
-                }
-                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                    Button(role: .destructive) {
-                        Task {
-                            await deleteRecipe(recipe)
-                        }
-                    } label: {
-                        Label("Delete", systemImage: "trash")
-                    }
-                    .tint(.red)
-
-                    Button {
-                        Task {
-                            try? await dependencies.recipeRepository.toggleFavorite(id: recipe.id)
-                            // Remove from local list since this is favorites view
-                            localRecipes.removeAll { $0.id == recipe.id }
-                        }
-                    } label: {
-                        Label("Unfavorite", systemImage: "star.slash")
-                    }
-                    .tint(.yellow)
-                }
-            }
+    private var resolvedRecipeLayoutMode: RecipeLayoutMode {
+        let storedMode = RecipeLayoutMode(rawValue: storedRecipeLayoutMode) ?? .auto
+        if storedMode == .auto {
+            return horizontalSizeClass == .regular ? .grid : .compact
         }
+        return storedMode
+    }
+
+    private var usesGridRecipeLayout: Bool {
+        resolvedRecipeLayoutMode == .grid
+    }
+
+    var body: some View {
+        contentView
         .navigationTitle("Favorites")
         .navigationBarTitleDisplayMode(.large)
         .onAppear {
@@ -69,6 +56,120 @@ struct FavoritesListView: View {
                 localRecipes.removeAll { $0.id == deletedRecipeId }
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                recipeLayoutMenu
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        if usesGridRecipeLayout {
+            gridContent
+        } else {
+            listContent
+        }
+    }
+
+    private var listContent: some View {
+        List {
+            Section {
+                Text("Recipes you've marked as favorites")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            ForEach(localRecipes) { recipe in
+                NavigationLink(destination: RecipeDetailView(recipe: recipe, dependencies: dependencies)) {
+                    RecipeRowView(recipe: recipe, dependencies: dependencies)
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    deleteButton(for: recipe)
+                    unfavoriteButton(for: recipe)
+                }
+            }
+        }
+    }
+
+    private var gridContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Recipes you've marked as favorites")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                LazyVGrid(columns: recipeGridColumns, spacing: 16) {
+                    ForEach(localRecipes) { recipe in
+                        NavigationLink(destination: RecipeDetailView(recipe: recipe, dependencies: dependencies)) {
+                            RecipeCardView(recipe: recipe, dependencies: dependencies)
+                        }
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            deleteButton(for: recipe)
+                            unfavoriteButton(for: recipe)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
+    }
+
+    private var recipeLayoutMenu: some View {
+        Menu {
+            Button {
+                storedRecipeLayoutMode = RecipeLayoutMode.grid.rawValue
+            } label: {
+                HStack {
+                    Label("Grid", systemImage: "square.grid.2x2")
+                    if resolvedRecipeLayoutMode == .grid {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+
+            Button {
+                storedRecipeLayoutMode = RecipeLayoutMode.compact.rawValue
+            } label: {
+                HStack {
+                    Label("Compact", systemImage: "list.bullet")
+                    if resolvedRecipeLayoutMode == .compact {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: resolvedRecipeLayoutMode == .grid ? "square.grid.2x2" : "list.bullet")
+        }
+    }
+
+    private func deleteButton(for recipe: Recipe) -> some View {
+        Button(role: .destructive) {
+            Task {
+                await deleteRecipe(recipe)
+            }
+        } label: {
+            Label("Delete", systemImage: "trash")
+        }
+        .tint(.red)
+    }
+
+    private func unfavoriteButton(for recipe: Recipe) -> some View {
+        Button {
+            Task {
+                try? await dependencies.recipeRepository.toggleFavorite(id: recipe.id)
+                localRecipes.removeAll { $0.id == recipe.id }
+            }
+        } label: {
+            Label("Unfavorite", systemImage: "star.slash")
+        }
+        .tint(.yellow)
+    }
+
+    private var recipeGridColumns: [GridItem] {
+        [GridItem(.adaptive(minimum: 240, maximum: 280), spacing: 16)]
     }
 
     private func deleteRecipe(_ recipe: Recipe) async {

--- a/Cauldron/Features/Cook/RecentlyCookedListView.swift
+++ b/Cauldron/Features/Cook/RecentlyCookedListView.swift
@@ -10,18 +10,12 @@ import os
 
 /// Full list view for recently cooked recipes
 struct RecentlyCookedListView: View {
-    private enum RecipeLayoutMode: String {
-        case auto
-        case compact
-        case grid
-    }
-
     let recipes: [Recipe]
     let dependencies: DependencyContainer
     
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var localRecipes: [Recipe]
-    @AppStorage("recipes.layoutMode") private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
+    @AppStorage(RecipeLayoutMode.appStorageKey) private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
 
     init(recipes: [Recipe], dependencies: DependencyContainer) {
         self.recipes = recipes
@@ -31,10 +25,7 @@ struct RecentlyCookedListView: View {
 
     private var resolvedRecipeLayoutMode: RecipeLayoutMode {
         let storedMode = RecipeLayoutMode(rawValue: storedRecipeLayoutMode) ?? .auto
-        if storedMode == .auto {
-            return horizontalSizeClass == .regular ? .grid : .compact
-        }
-        return storedMode
+        return storedMode.resolved(for: horizontalSizeClass)
     }
 
     private var usesGridRecipeLayout: Bool {
@@ -106,30 +97,8 @@ struct RecentlyCookedListView: View {
     }
 
     private var recipeLayoutMenu: some View {
-        Menu {
-            Button {
-                storedRecipeLayoutMode = RecipeLayoutMode.grid.rawValue
-            } label: {
-                HStack {
-                    Label("Grid", systemImage: "square.grid.2x2")
-                    if resolvedRecipeLayoutMode == .grid {
-                        Image(systemName: "checkmark")
-                    }
-                }
-            }
-
-            Button {
-                storedRecipeLayoutMode = RecipeLayoutMode.compact.rawValue
-            } label: {
-                HStack {
-                    Label("Compact", systemImage: "list.bullet")
-                    if resolvedRecipeLayoutMode == .compact {
-                        Image(systemName: "checkmark")
-                    }
-                }
-            }
-        } label: {
-            Image(systemName: resolvedRecipeLayoutMode == .grid ? "square.grid.2x2" : "list.bullet")
+        RecipeLayoutToolbarButton(resolvedMode: resolvedRecipeLayoutMode) { mode in
+            storedRecipeLayoutMode = mode.rawValue
         }
     }
 
@@ -177,7 +146,7 @@ struct RecentlyCookedListView: View {
     }
 
     private var recipeGridColumns: [GridItem] {
-        [GridItem(.adaptive(minimum: 240, maximum: 280), spacing: 16)]
+        RecipeLayoutMode.defaultGridColumns
     }
 
     private func deleteRecipe(_ recipe: Recipe) async {

--- a/Cauldron/Features/Library/RecipeDetailView.swift
+++ b/Cauldron/Features/Library/RecipeDetailView.swift
@@ -11,6 +11,7 @@ struct RecipeDetailView: View {
     let dependencies: DependencyContainer
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State var recipe: Recipe
     @State private var showingEditSheet = false
     @State var showSessionConflictAlert = false
@@ -84,6 +85,10 @@ struct RecipeDetailView: View {
         scaledResult.recipe
     }
 
+    private var shouldApplyBackgroundExtensionEffect: Bool {
+        horizontalSizeClass == .regular
+    }
+
     var body: some View {
         ZStack(alignment: .bottom) {
             ScrollViewReader { scrollProxy in
@@ -91,6 +96,7 @@ struct RecipeDetailView: View {
                     VStack(alignment: .leading, spacing: 0) {
                         if recipe.imageURL != nil || recipe.cloudImageRecordName != nil {
                             HeroRecipeImageView(recipe: recipe, recipeImageService: dependencies.recipeImageService)
+                                .backgroundExtensionEffect(isEnabled: shouldApplyBackgroundExtensionEffect)
                                 .ignoresSafeArea(edges: .top)
                                 .id("\(recipe.imageURL?.absoluteString ?? "no-url")-\(recipe.id)-\(imageRefreshID)")
                         }

--- a/Cauldron/Features/Library/RecipeDetailView.swift
+++ b/Cauldron/Features/Library/RecipeDetailView.swift
@@ -89,66 +89,126 @@ struct RecipeDetailView: View {
         horizontalSizeClass == .regular
     }
 
+    private var hasHeroImage: Bool {
+        recipe.imageURL != nil || recipe.cloudImageRecordName != nil
+    }
+
+    private var recipeHeaderSection: some View {
+        RecipeHeaderSection(
+            recipe: recipe,
+            scaledRecipe: scaledRecipe,
+            scaledResult: scaledResult,
+            scaleFactor: $scaleFactor,
+            currentVisibility: $currentVisibility,
+            localIsFavorite: $localIsFavorite,
+            hasOwnedCopy: hasOwnedCopy,
+            isSavingRecipe: isSavingRecipe,
+            isCheckingDuplicates: isCheckingDuplicates,
+            hasUpdates: hasUpdates,
+            isUpdatingRecipe: isUpdatingRecipe,
+            isLoadingCreator: isLoadingCreator,
+            sharedBy: sharedBy,
+            recipeOwner: recipeOwner,
+            originalCreator: originalCreator,
+            dependencies: dependencies,
+            onToggleFavorite: toggleFavorite,
+            onChangeVisibility: changeVisibility,
+            onSaveRecipe: saveRecipeToLibrary,
+            onUpdateRecipe: updateRecipeCopy
+        )
+        .padding(.top, hasHeroImage ? -80 : 0)
+    }
+
+    @ViewBuilder
+    private var notesSection: some View {
+        if let notes = recipe.notes, !notes.isEmpty {
+            RecipeNotesSection(notes: notes)
+        }
+    }
+
+    private var ingredientsSection: some View {
+        RecipeIngredientsSection(ingredients: scaledRecipe.ingredients)
+    }
+
+    private var stepsSection: some View {
+        RecipeStepsSection(
+            steps: scaledRecipe.steps,
+            highlightedStepIndex: highlightedStepIndex,
+            onTimerTap: startTimer
+        )
+    }
+
+    @ViewBuilder
+    private var nutritionSection: some View {
+        if let nutrition = recipe.nutrition, nutrition.hasData {
+            RecipeNutritionSection(nutrition: nutrition)
+        }
+    }
+
+    @ViewBuilder
+    private var relatedSection: some View {
+        if !relatedRecipes.isEmpty {
+            RecipeRelatedSection(relatedRecipes: relatedRecipes, dependencies: dependencies)
+        }
+    }
+
+    @ViewBuilder
+    private var compactRecipeContent: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            recipeHeaderSection
+            notesSection
+            ingredientsSection
+            stepsSection
+            nutritionSection
+            relatedSection
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, hasHeroImage ? 0 : 20)
+        .padding(.bottom, 100)
+    }
+
+    @ViewBuilder
+    private var regularRecipeContent: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            recipeHeaderSection
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(alignment: .top, spacing: 20) {
+                VStack(alignment: .leading, spacing: 20) {
+                    ingredientsSection
+                    notesSection
+                }
+                .frame(maxWidth: 430, alignment: .leading)
+
+                stepsSection
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            nutritionSection
+            relatedSection
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, hasHeroImage ? 0 : 20)
+        .padding(.bottom, 100)
+    }
+
     var body: some View {
         ZStack(alignment: .bottom) {
             ScrollViewReader { scrollProxy in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
-                        if recipe.imageURL != nil || recipe.cloudImageRecordName != nil {
+                        if hasHeroImage {
                             HeroRecipeImageView(recipe: recipe, recipeImageService: dependencies.recipeImageService)
                                 .backgroundExtensionEffect(isEnabled: shouldApplyBackgroundExtensionEffect)
                                 .ignoresSafeArea(edges: .top)
                                 .id("\(recipe.imageURL?.absoluteString ?? "no-url")-\(recipe.id)-\(imageRefreshID)")
                         }
 
-                        VStack(alignment: .leading, spacing: 20) {
-                            RecipeHeaderSection(
-                                recipe: recipe,
-                                scaledRecipe: scaledRecipe,
-                                scaledResult: scaledResult,
-                                scaleFactor: $scaleFactor,
-                                currentVisibility: $currentVisibility,
-                                localIsFavorite: $localIsFavorite,
-                                hasOwnedCopy: hasOwnedCopy,
-                                isSavingRecipe: isSavingRecipe,
-                                isCheckingDuplicates: isCheckingDuplicates,
-                                hasUpdates: hasUpdates,
-                                isUpdatingRecipe: isUpdatingRecipe,
-                                isLoadingCreator: isLoadingCreator,
-                                sharedBy: sharedBy,
-                                recipeOwner: recipeOwner,
-                                originalCreator: originalCreator,
-                                dependencies: dependencies,
-                                onToggleFavorite: toggleFavorite,
-                                onChangeVisibility: changeVisibility,
-                                onSaveRecipe: saveRecipeToLibrary,
-                                onUpdateRecipe: updateRecipeCopy
-                            )
-                            .padding(.top, (recipe.imageURL != nil || recipe.cloudImageRecordName != nil) ? -80 : 0)
-
-                            if let notes = recipe.notes, !notes.isEmpty {
-                                RecipeNotesSection(notes: notes)
-                            }
-
-                            RecipeIngredientsSection(ingredients: scaledRecipe.ingredients)
-
-                            RecipeStepsSection(
-                                steps: scaledRecipe.steps,
-                                highlightedStepIndex: highlightedStepIndex,
-                                onTimerTap: startTimer
-                            )
-
-                            if let nutrition = recipe.nutrition, nutrition.hasData {
-                                RecipeNutritionSection(nutrition: nutrition)
-                            }
-
-                            if !relatedRecipes.isEmpty {
-                                RecipeRelatedSection(relatedRecipes: relatedRecipes, dependencies: dependencies)
-                            }
+                        if horizontalSizeClass == .regular {
+                            regularRecipeContent
+                        } else {
+                            compactRecipeContent
                         }
-                        .padding(.horizontal, 16)
-                        .padding(.top, recipe.imageURL != nil ? 0 : 20)
-                        .padding(.bottom, 100)
                     }
                 }
                 .onAppear {
@@ -161,7 +221,7 @@ struct RecipeDetailView: View {
                     }
                 }
             }
-            .ignoresSafeArea(edges: (recipe.imageURL != nil || recipe.cloudImageRecordName != nil) ? .top : [])
+            .ignoresSafeArea(edges: hasHeroImage ? .top : [])
 
             HStack {
                 Spacer()

--- a/Cauldron/Features/Profile/UserProfileView.swift
+++ b/Cauldron/Features/Profile/UserProfileView.swift
@@ -942,14 +942,9 @@ struct CollectionCardCompact: View {
                     .fill(selectedColor.opacity(0.15))
                     .frame(width: 80, height: 80)
 
-                if let emoji = collection.emoji {
-                    Text(emoji)
-                        .font(.system(size: 40))
-                } else {
-                    Image(systemName: "folder.fill")
-                        .font(.system(size: 36))
-                        .foregroundColor(selectedColor)
-                }
+                Image(systemName: collection.symbolName ?? "folder.fill")
+                    .font(.system(size: 36))
+                    .foregroundColor(selectedColor)
             }
 
             // Collection name

--- a/Cauldron/Features/Profile/UserProfileView.swift
+++ b/Cauldron/Features/Profile/UserProfileView.swift
@@ -976,8 +976,41 @@ struct AllProfileRecipesListView: View {
     let recipes: [SharedRecipe]
     let user: User
     let dependencies: DependencyContainer
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @AppStorage(RecipeLayoutMode.appStorageKey) private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
+
+    private var resolvedRecipeLayoutMode: RecipeLayoutMode {
+        let storedMode = RecipeLayoutMode(rawValue: storedRecipeLayoutMode) ?? .auto
+        return storedMode.resolved(for: horizontalSizeClass)
+    }
+
+    private var usesGridRecipeLayout: Bool {
+        resolvedRecipeLayoutMode == .grid
+    }
 
     var body: some View {
+        contentView
+        .navigationTitle("\(user.displayName)'s Recipes")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                RecipeLayoutToolbarButton(resolvedMode: resolvedRecipeLayoutMode) { mode in
+                    storedRecipeLayoutMode = mode.rawValue
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        if usesGridRecipeLayout {
+            gridContent
+        } else {
+            listContent
+        }
+    }
+
+    private var listContent: some View {
         List {
             ForEach(recipes) { sharedRecipe in
                 NavigationLink(destination: RecipeDetailView(
@@ -990,8 +1023,26 @@ struct AllProfileRecipesListView: View {
                 }
             }
         }
-        .navigationTitle("\(user.displayName)'s Recipes")
-        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var gridContent: some View {
+        ScrollView {
+            LazyVGrid(columns: RecipeLayoutMode.defaultGridColumns, spacing: 16) {
+                ForEach(recipes) { sharedRecipe in
+                    NavigationLink(destination: RecipeDetailView(
+                        recipe: sharedRecipe.recipe,
+                        dependencies: dependencies,
+                        sharedBy: sharedRecipe.sharedBy,
+                        sharedAt: sharedRecipe.sharedAt
+                    )) {
+                        RecipeCardView(sharedRecipe: sharedRecipe, dependencies: dependencies)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
     }
 }
 

--- a/Cauldron/Features/Search/ExploreTagView.swift
+++ b/Cauldron/Features/Search/ExploreTagView.swift
@@ -388,8 +388,41 @@ struct TagRecipesListView: View {
     let recipes: [Recipe]
     let dependencies: DependencyContainer
     let color: Color
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @AppStorage(RecipeLayoutMode.appStorageKey) private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
+
+    private var resolvedRecipeLayoutMode: RecipeLayoutMode {
+        let storedMode = RecipeLayoutMode(rawValue: storedRecipeLayoutMode) ?? .auto
+        return storedMode.resolved(for: horizontalSizeClass)
+    }
+
+    private var usesGridRecipeLayout: Bool {
+        resolvedRecipeLayoutMode == .grid
+    }
 
     var body: some View {
+        contentView
+        .navigationTitle("All Recipes")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                RecipeLayoutToolbarButton(resolvedMode: resolvedRecipeLayoutMode) { mode in
+                    storedRecipeLayoutMode = mode.rawValue
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        if usesGridRecipeLayout {
+            gridContent
+        } else {
+            listContent
+        }
+    }
+
+    private var listContent: some View {
         List {
             ForEach(recipes) { recipe in
                 NavigationLink(destination: RecipeDetailView(recipe: recipe, dependencies: dependencies)) {
@@ -397,8 +430,21 @@ struct TagRecipesListView: View {
                 }
             }
         }
-        .navigationTitle("All Recipes")
-        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var gridContent: some View {
+        ScrollView {
+            LazyVGrid(columns: RecipeLayoutMode.defaultGridColumns, spacing: 16) {
+                ForEach(recipes) { recipe in
+                    NavigationLink(destination: RecipeDetailView(recipe: recipe, dependencies: dependencies)) {
+                        RecipeCardView(recipe: recipe, dependencies: dependencies)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
     }
 }
 
@@ -407,8 +453,41 @@ struct TagFriendRecipesListView: View {
     let sharedRecipes: [SharedRecipe]
     let dependencies: DependencyContainer
     let color: Color
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @AppStorage(RecipeLayoutMode.appStorageKey) private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
+
+    private var resolvedRecipeLayoutMode: RecipeLayoutMode {
+        let storedMode = RecipeLayoutMode(rawValue: storedRecipeLayoutMode) ?? .auto
+        return storedMode.resolved(for: horizontalSizeClass)
+    }
+
+    private var usesGridRecipeLayout: Bool {
+        resolvedRecipeLayoutMode == .grid
+    }
 
     var body: some View {
+        contentView
+        .navigationTitle("From Friends")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                RecipeLayoutToolbarButton(resolvedMode: resolvedRecipeLayoutMode) { mode in
+                    storedRecipeLayoutMode = mode.rawValue
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        if usesGridRecipeLayout {
+            gridContent
+        } else {
+            listContent
+        }
+    }
+
+    private var listContent: some View {
         List {
             ForEach(sharedRecipes) { sharedRecipe in
                 NavigationLink(destination: RecipeDetailView(
@@ -421,8 +500,26 @@ struct TagFriendRecipesListView: View {
                 }
             }
         }
-        .navigationTitle("From Friends")
-        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var gridContent: some View {
+        ScrollView {
+            LazyVGrid(columns: RecipeLayoutMode.defaultGridColumns, spacing: 16) {
+                ForEach(sharedRecipes) { sharedRecipe in
+                    NavigationLink(destination: RecipeDetailView(
+                        recipe: sharedRecipe.recipe,
+                        dependencies: dependencies,
+                        sharedBy: sharedRecipe.sharedBy,
+                        sharedAt: sharedRecipe.sharedAt
+                    )) {
+                        RecipeCardView(sharedRecipe: sharedRecipe, dependencies: dependencies)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
     }
 }
 
@@ -431,8 +528,41 @@ struct TagPublicRecipesListView: View {
     let recipes: [SharedRecipe]
     let dependencies: DependencyContainer
     let color: Color
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @AppStorage(RecipeLayoutMode.appStorageKey) private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
+
+    private var resolvedRecipeLayoutMode: RecipeLayoutMode {
+        let storedMode = RecipeLayoutMode(rawValue: storedRecipeLayoutMode) ?? .auto
+        return storedMode.resolved(for: horizontalSizeClass)
+    }
+
+    private var usesGridRecipeLayout: Bool {
+        resolvedRecipeLayoutMode == .grid
+    }
 
     var body: some View {
+        contentView
+        .navigationTitle("Community Recipes")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                RecipeLayoutToolbarButton(resolvedMode: resolvedRecipeLayoutMode) { mode in
+                    storedRecipeLayoutMode = mode.rawValue
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        if usesGridRecipeLayout {
+            gridContent
+        } else {
+            listContent
+        }
+    }
+
+    private var listContent: some View {
         List {
             ForEach(recipes) { sharedRecipe in
                 NavigationLink(destination: RecipeDetailView(
@@ -444,8 +574,25 @@ struct TagPublicRecipesListView: View {
                 }
             }
         }
-        .navigationTitle("Community Recipes")
-        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var gridContent: some View {
+        ScrollView {
+            LazyVGrid(columns: RecipeLayoutMode.defaultGridColumns, spacing: 16) {
+                ForEach(recipes) { sharedRecipe in
+                    NavigationLink(destination: RecipeDetailView(
+                        recipe: sharedRecipe.recipe,
+                        dependencies: dependencies,
+                        sharedBy: sharedRecipe.sharedBy
+                    )) {
+                        RecipeCardView(sharedRecipe: sharedRecipe, dependencies: dependencies)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
     }
 }
 

--- a/Cauldron/Features/Search/SearchTabView.swift
+++ b/Cauldron/Features/Search/SearchTabView.swift
@@ -12,6 +12,7 @@ import os
 struct SearchTabView: View {
     @State private var viewModel: SearchTabViewModel
     @StateObject private var currentUserSession = CurrentUserSession.shared
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var searchText = ""
     @State private var searchMode: SearchMode = .recipes
     @State private var showingProfileSheet = false
@@ -27,102 +28,54 @@ struct SearchTabView: View {
         _viewModel = State(initialValue: SearchTabViewModel(dependencies: dependencies))
         _navigationPath = navigationPath
     }
-    
+
+    private var isRegularWidth: Bool {
+        horizontalSizeClass == .regular
+    }
+
     var body: some View {
-        NavigationStack(path: $navigationPath) {
-            VStack(spacing: 0) {
-                // Search mode picker
-                Picker("Search Mode", selection: $searchMode) {
-                    ForEach(SearchMode.allCases, id: \.self) { mode in
-                        Text(mode.rawValue).tag(mode)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .padding()
-                
-                // Content based on search mode
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 24) {
-                        if searchMode == .recipes {
-                            if searchText.isEmpty && viewModel.selectedCategories.isEmpty {
-                                // Show categories when not searching and no filters
-                                categoriesView
-                            } else {
-                                // Show recipe search results (filtered by text or categories)
-                                recipeSearchResultsView
-                            }
-                        } else {
-                            // Show people search
-                            peopleSearchView
-                        }
-                    }
-                    .padding()
-                }
-            }
-            .navigationTitle("Search")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    if let user = currentUserSession.currentUser {
-                        Button {
-                            showingProfileSheet = true
-                        } label: {
-                            ProfileAvatar(user: user, size: 32, dependencies: viewModel.dependencies)
-                        }
-                    }
-                }
-            }
-            .sheet(isPresented: $showingProfileSheet) {
-                NavigationStack {
-                    if let user = currentUserSession.currentUser {
-                        UserProfileView(user: user, dependencies: viewModel.dependencies)
-                            .toolbar {
-                                ToolbarItem(placement: .confirmationAction) {
-                                    Button("Done") { showingProfileSheet = false }
-                                }
-                            }
-                    }
-                }
-            }
-            .task {
-                await viewModel.loadData()
-            }
-            .refreshable {
-                await viewModel.loadData()
-            }
-            .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("RecipeDeleted"))) { _ in
-                Task {
-                    await viewModel.loadData()
-                }
-            }
-            .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("RecipeUpdated"))) { _ in
-                Task {
-                    await viewModel.loadData()
-                }
-            }
-            .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("RecipeAdded"))) { _ in
-                Task {
-                    await viewModel.loadData()
-                }
-            }
-            .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("SwitchToSearchTab"))) { _ in
-                // Switch to People search mode when coming from Friends empty state
-                searchMode = .people
-                searchText = "" // Clear any existing search
-            }
-            .navigationDestination(for: Recipe.self) { recipe in
-                RecipeDetailView(recipe: recipe, dependencies: viewModel.dependencies)
-            }
-            .navigationDestination(for: User.self) { user in
-                UserProfileView(user: user, dependencies: viewModel.dependencies)
-            }
-            .navigationDestination(for: Collection.self) { collection in
-                CollectionDetailView(collection: collection, dependencies: viewModel.dependencies)
-            }
-            .navigationDestination(for: Tag.self) { tag in
-                ExploreTagView(tag: tag, dependencies: viewModel.dependencies)
+        Group {
+            if isRegularWidth {
+                splitView
+            } else {
+                compactView
             }
         }
-        .searchable(text: $searchText, prompt: searchMode == .recipes ? "Search recipes" : "Search people")
+        .sheet(isPresented: $showingProfileSheet) {
+            NavigationStack {
+                if let user = currentUserSession.currentUser {
+                    UserProfileView(user: user, dependencies: viewModel.dependencies)
+                        .toolbar {
+                            ToolbarItem(placement: .confirmationAction) {
+                                Button("Done") { showingProfileSheet = false }
+                            }
+                        }
+                }
+            }
+        }
+        .task {
+            await viewModel.loadData()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("RecipeDeleted"))) { _ in
+            Task {
+                await viewModel.loadData()
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("RecipeUpdated"))) { _ in
+            Task {
+                await viewModel.loadData()
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("RecipeAdded"))) { _ in
+            Task {
+                await viewModel.loadData()
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("SwitchToSearchTab"))) { _ in
+            // Switch to People search mode when coming from Friends empty state
+            searchMode = .people
+            searchText = "" // Clear any existing search
+        }
         .onChange(of: searchText) { _, newValue in
             if searchMode == .recipes {
                 viewModel.updateRecipeSearch(newValue)
@@ -133,6 +86,124 @@ struct SearchTabView: View {
         .onChange(of: searchMode) { _, _ in
             // Clear search when switching modes
             searchText = ""
+        }
+    }
+
+    private var compactView: some View {
+        NavigationStack(path: $navigationPath) {
+            searchContent
+                .navigationTitle("Search")
+                .toolbar { searchToolbar }
+                .refreshable {
+                    await viewModel.loadData()
+                }
+                .navigationDestination(for: Recipe.self) { recipe in
+                    RecipeDetailView(recipe: recipe, dependencies: viewModel.dependencies)
+                }
+                .navigationDestination(for: User.self) { user in
+                    UserProfileView(user: user, dependencies: viewModel.dependencies)
+                }
+                .navigationDestination(for: Collection.self) { collection in
+                    CollectionDetailView(collection: collection, dependencies: viewModel.dependencies)
+                }
+                .navigationDestination(for: Tag.self) { tag in
+                    ExploreTagView(tag: tag, dependencies: viewModel.dependencies)
+                }
+        }
+        .searchable(text: $searchText, prompt: searchMode == .recipes ? "Search recipes" : "Search people")
+    }
+
+    private var splitView: some View {
+        NavigationSplitView {
+            searchContent
+                .navigationTitle("Search")
+                .toolbar { searchToolbar }
+                .navigationSplitViewColumnWidth(min: 320, ideal: 360, max: 420)
+                .refreshable {
+                    await viewModel.loadData()
+                }
+        } detail: {
+            NavigationStack(path: $navigationPath) {
+                splitDetailPlaceholder
+                    .navigationDestination(for: Recipe.self) { recipe in
+                        RecipeDetailView(recipe: recipe, dependencies: viewModel.dependencies)
+                    }
+                    .navigationDestination(for: User.self) { user in
+                        UserProfileView(user: user, dependencies: viewModel.dependencies)
+                    }
+                    .navigationDestination(for: Collection.self) { collection in
+                        CollectionDetailView(collection: collection, dependencies: viewModel.dependencies)
+                    }
+                    .navigationDestination(for: Tag.self) { tag in
+                        ExploreTagView(tag: tag, dependencies: viewModel.dependencies)
+                    }
+            }
+        }
+        .navigationSplitViewStyle(.balanced)
+        .searchable(
+            text: $searchText,
+            placement: .sidebar,
+            prompt: searchMode == .recipes ? "Search recipes" : "Search people"
+        )
+    }
+
+    private var searchContent: some View {
+        VStack(spacing: 0) {
+            // Search mode picker
+            Picker("Search Mode", selection: $searchMode) {
+                ForEach(SearchMode.allCases, id: \.self) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            // Content based on search mode
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    if searchMode == .recipes {
+                        if searchText.isEmpty && viewModel.selectedCategories.isEmpty {
+                            // Show categories when not searching and no filters
+                            categoriesView
+                        } else {
+                            // Show recipe search results (filtered by text or categories)
+                            recipeSearchResultsView
+                        }
+                    } else {
+                        // Show people search
+                        peopleSearchView
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+
+    private var splitDetailPlaceholder: some View {
+        VStack(spacing: 16) {
+            Image(systemName: searchMode == .recipes ? "fork.knife" : "person.2")
+                .font(.system(size: 44))
+                .foregroundStyle(.secondary)
+
+            Text(searchMode == .recipes ? "Select a recipe to view details" : "Select a person to view profile")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.cauldronBackground.ignoresSafeArea())
+    }
+
+    @ToolbarContentBuilder
+    private var searchToolbar: some ToolbarContent {
+        ToolbarItem(placement: .navigationBarLeading) {
+            if let user = currentUserSession.currentUser {
+                Button {
+                    showingProfileSheet = true
+                } label: {
+                    ProfileAvatar(user: user, size: 32, dependencies: viewModel.dependencies)
+                }
+            }
         }
     }
     
@@ -241,8 +312,8 @@ struct SearchTabView: View {
                         .padding(.top, 8)
                     
                     ForEach(viewModel.friends) { user in
-                        NavigationLink {
-                            UserProfileView(user: user, dependencies: viewModel.dependencies)
+                        Button {
+                            navigationPath.append(user)
                         } label: {
                             UserSearchRowView(
                                 user: user,
@@ -260,8 +331,8 @@ struct SearchTabView: View {
                             .padding(.top, 24)
                         
                         ForEach(viewModel.recommendedUsers) { user in
-                            NavigationLink {
-                                UserProfileView(user: user, dependencies: viewModel.dependencies)
+                            Button {
+                                navigationPath.append(user)
                             } label: {
                                 UserSearchRowView(
                                     user: user,
@@ -322,8 +393,8 @@ struct SearchTabView: View {
                 }
                 
                 ForEach(viewModel.peopleSearchResults) { user in
-                    NavigationLink {
-                        UserProfileView(user: user, dependencies: viewModel.dependencies)
+                    Button {
+                        navigationPath.append(user)
                     } label: {
                         UserSearchRowView(
                             user: user,

--- a/Cauldron/Features/Sharing/SharedCollectionDetailView.swift
+++ b/Cauldron/Features/Sharing/SharedCollectionDetailView.swift
@@ -9,12 +9,6 @@ import SwiftUI
 import os
 
 struct SharedCollectionDetailView: View {
-    private enum RecipeLayoutMode: String {
-        case auto
-        case compact
-        case grid
-    }
-
     let collection: Collection
     let dependencies: DependencyContainer
 
@@ -27,7 +21,7 @@ struct SharedCollectionDetailView: View {
     @State private var collectionOwner: User?
     @Environment(\.dismiss) private var dismiss
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @AppStorage("recipes.layoutMode") private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
+    @AppStorage(RecipeLayoutMode.appStorageKey) private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
 
     private var loader: SharedCollectionLoader {
         SharedCollectionLoader(dependencies: dependencies)
@@ -35,10 +29,7 @@ struct SharedCollectionDetailView: View {
 
     private var resolvedRecipeLayoutMode: RecipeLayoutMode {
         let storedMode = RecipeLayoutMode(rawValue: storedRecipeLayoutMode) ?? .auto
-        if storedMode == .auto {
-            return horizontalSizeClass == .regular ? .grid : .compact
-        }
-        return storedMode
+        return storedMode.resolved(for: horizontalSizeClass)
     }
 
     private var usesGridRecipeLayout: Bool {
@@ -46,30 +37,8 @@ struct SharedCollectionDetailView: View {
     }
 
     private var recipeLayoutMenu: some View {
-        Menu {
-            Button {
-                storedRecipeLayoutMode = RecipeLayoutMode.grid.rawValue
-            } label: {
-                HStack {
-                    Label("Grid", systemImage: "square.grid.2x2")
-                    if resolvedRecipeLayoutMode == .grid {
-                        Image(systemName: "checkmark")
-                    }
-                }
-            }
-
-            Button {
-                storedRecipeLayoutMode = RecipeLayoutMode.compact.rawValue
-            } label: {
-                HStack {
-                    Label("Compact", systemImage: "list.bullet")
-                    if resolvedRecipeLayoutMode == .compact {
-                        Image(systemName: "checkmark")
-                    }
-                }
-            }
-        } label: {
-            Image(systemName: resolvedRecipeLayoutMode == .grid ? "square.grid.2x2" : "list.bullet")
+        RecipeLayoutToolbarButton(resolvedMode: resolvedRecipeLayoutMode) { mode in
+            storedRecipeLayoutMode = mode.rawValue
         }
     }
 

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -47,6 +47,14 @@
                 "function": "previewCollection"
             },
             {
+                "source": "/invite",
+                "function": "previewInvite"
+            },
+            {
+                "source": "/invite/**",
+                "function": "previewInvite"
+            },
+            {
                 "source": "/api/**",
                 "function": "api"
             }

--- a/firebase/public/.well-known/apple-app-site-association
+++ b/firebase/public/.well-known/apple-app-site-association
@@ -6,6 +6,8 @@
                 "appID": "C4MRP56MF5.Nadav.Cauldron",
                 "paths": [
                     "/recipe/*",
+                    "/invite",
+                    "/invite/*",
                     "/profile/*",
                     "/collection/*"
                 ]
@@ -14,6 +16,8 @@
                 "appID": "C4MRP56MF5.Nadav.Cauldron.dev",
                 "paths": [
                     "/recipe/*",
+                    "/invite",
+                    "/invite/*",
                     "/profile/*",
                     "/collection/*"
                 ]


### PR DESCRIPTION
Summary
- default recipe collections/all-recipes screens to the standard grid card layout and expose view-switching controls in the toolbar
tools for importer/search? mention? maybe not.
- clean up parsing/import toolchain improvements and parity tests to support these UI changes
Testing
- Not run (not requested)