### PR TITLE
Update versions and release notes for Mac Catalyst launch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository.
+
+## Project Snapshot
+- App: `Cauldron` (SwiftUI-first recipe app)
+- Main targets: iOS/iPad app, Mac Catalyst app, Widget extension, Share extension
+- Core backend: CloudKit (+ Firebase for share-link hosting endpoints)
+- Parser stack: model-backed import pipeline with parity-tested assembly
+
+## Repository Layout
+- App code: `/Users/nadav/Desktop/Cauldron/Cauldron`
+- Tests: `/Users/nadav/Desktop/Cauldron/CauldronTests`
+- Share extension: `/Users/nadav/Desktop/Cauldron/CauldronShareExtension`
+- Widget: `/Users/nadav/Desktop/Cauldron/CauldronWidget`
+- Parser tooling/labs: `/Users/nadav/Desktop/Cauldron/tools`
+
+## Build And Test Commands
+- iOS build:
+  - `xcodebuild build -scheme Cauldron -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug CODE_SIGNING_ALLOWED=NO`
+- Mac Catalyst build:
+  - `xcodebuild build -scheme Cauldron -destination 'platform=macOS,variant=Mac Catalyst,name=My Mac' -configuration Debug CODE_SIGNING_ALLOWED=NO`
+- iOS tests:
+  - `xcodebuild test -scheme Cauldron -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug CODE_SIGNING_ALLOWED=NO`
+- Mac Catalyst tests:
+  - `xcodebuild test -scheme Cauldron -destination 'platform=macOS,variant=Mac Catalyst,name=My Mac' -configuration Debug CODE_SIGNING_ALLOWED=NO`
+
+## Current Product Priorities
+- Maintain first-class iPad and Mac experiences (not only iPhone layouts)
+- Preserve parser quality and import consistency across share sheet, URL, and text flows
+- Keep social/invite flows stable and performant
+- Favor practical incremental changes over broad refactors unless requested
+
+## Critical Features And Behaviors
+- Import quality is core product value:
+  - Model-backed parser + shared import pipeline should stay consistent across URL, text, and share-extension entry points.
+  - Parser behavior changes should keep parity/regression tests green.
+- Social sharing is a core workflow:
+  - Invite links/referrals, friend connections, and profile/friends UX should remain reliable and low-friction.
+  - CloudKit + Firebase share-link behavior must remain compatible with associated domains and app routing.
+- Large-screen experience is intentional:
+  - iPad layouts are first-class, not stretched iPhone views.
+  - Mac app behavior is intentionally supported via Mac Catalyst target configuration.
+- Offline-first sync reliability matters:
+  - Operation queue + CloudKit sync paths should not be bypassed without a clear migration plan.
+- Update-surface behavior matters:
+  - `What's New` is gated by content version and should be updated for meaningful user-visible changes.
+
+## Release/Update Checklist
+- App versioning is managed in:
+  - `/Users/nadav/Desktop/Cauldron/Cauldron.xcodeproj/project.pbxproj`
+  - `MARKETING_VERSION` should be updated consistently across targets.
+- "What’s New" screen:
+  - UI content: `/Users/nadav/Desktop/Cauldron/Cauldron/Features/Settings/WhatsNewView.swift`
+  - show-once content gate: `/Users/nadav/Desktop/Cauldron/Cauldron/ContentView.swift` (`whatsNewContentVersion`)
+- If update text changes materially, bump `whatsNewContentVersion` so existing users see it.
+
+## Platform Notes
+- Mac app path is Mac Catalyst-enabled in the main target.
+- Embedded iOS extensions are filtered for iOS-only embedding in project settings.
+- ActivityKit/Live Activities are conditionally excluded from Mac Catalyst code paths.
+
+## Working Norms
+- Keep SwiftUI code idiomatic and readable; prefer focused edits over wide churn.
+- When touching parser or import flows, run relevant parser/import tests before finalizing.
+- Avoid modifying unrelated files in a dirty worktree.
+- Do not remove existing product behavior unless explicitly requested.
+
+## AGENTS.md Maintenance Rules
+- Update this file in the same PR whenever any of the following changes:
+  - Build/test commands, destinations, scheme names, or required flags
+  - App targets/platform support (iOS/iPad/Mac Catalyst/extension behavior)
+  - Core architecture boundaries (new layer, service ownership shift, major DI changes)
+  - Critical feature workflows (import/parser pipeline, sharing/invites, sync model)
+  - Release/update process (`MARKETING_VERSION`, `What's New` gating, rollout steps)
+- Keep updates minimal and factual; prefer editing existing sections over adding noisy new ones.
+- If a change is temporary, annotate it as temporary and include expected cleanup timing.

--- a/Cauldron.xcodeproj/project.pbxproj
+++ b/Cauldron.xcodeproj/project.pbxproj
@@ -9,8 +9,8 @@
 /* Begin PBXBuildFile section */
 		AE678DA22EB9545B00786709 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE678DA12EB9545B00786709 /* WidgetKit.framework */; };
 		AE678DA42EB9545B00786709 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE678DA32EB9545B00786709 /* SwiftUI.framework */; };
-		AE678DB52EB9545C00786709 /* CauldronWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = AE678D9F2EB9545B00786709 /* CauldronWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		B1A2B3C42F00000100AAA001 /* CauldronShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B1A2B3C42F00000100AAA003 /* CauldronShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		AE678DB52EB9545C00786709 /* CauldronWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = AE678D9F2EB9545B00786709 /* CauldronWidgetExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		B1A2B3C42F00000100AAA001 /* CauldronShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B1A2B3C42F00000100AAA003 /* CauldronShareExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -567,12 +567,13 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = Nadav.Cauldron.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -610,12 +611,13 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = Nadav.Cauldron;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -642,7 +644,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = Nadav.Cauldron.dev.CauldronWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -672,7 +674,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = Nadav.Cauldron.CauldronWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -693,7 +695,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = C4MRP56MF5;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = Nadav.CauldronTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -714,7 +716,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = C4MRP56MF5;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = Nadav.CauldronTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -742,7 +744,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = Nadav.Cauldron.dev.CauldronShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -770,7 +772,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = Nadav.Cauldron.CauldronShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Cauldron/ContentView.swift
+++ b/Cauldron/ContentView.swift
@@ -27,9 +27,9 @@ struct ContentView: View {
     // MARK: - What's New Content Versioning
     // Only update this when you have NEW FEATURES to announce.
     // This is separate from the build number - the app can have multiple builds without triggering What's New.
-    // When you ship a feature update, set this to match that version (e.g., "1.1.2").
+    // When you ship a feature update, set this to match that version (e.g., "1.3").
     // When you ship a bug fix, leave this unchanged so no splash appears.
-    private static let whatsNewContentVersion = "1.1.2"
+    private static let whatsNewContentVersion = "1.3"
 
     @Environment(\.dependencies) private var dependencies
     @StateObject private var userSession = CurrentUserSession.shared

--- a/Cauldron/Core/AppIntents/CookModeIntents.swift
+++ b/Cauldron/Core/AppIntents/CookModeIntents.swift
@@ -8,6 +8,7 @@
 import AppIntents
 import Foundation
 
+#if canImport(ActivityKit) && !targetEnvironment(macCatalyst)
 /// App Intent to navigate to the next step in cook mode
 struct NextStepIntent: LiveActivityIntent {
     static var title: LocalizedStringResource = "Next Step"
@@ -78,3 +79,4 @@ struct PreviousStepIntent: LiveActivityIntent {
         return .result()
     }
 }
+#endif

--- a/Cauldron/Core/Models/CookModeActivityAttributes.swift
+++ b/Cauldron/Core/Models/CookModeActivityAttributes.swift
@@ -5,8 +5,10 @@
 //  Created for Live Activities support
 //
 
-import ActivityKit
 import Foundation
+
+#if canImport(ActivityKit) && !targetEnvironment(macCatalyst)
+import ActivityKit
 
 /// Attributes for the Cook Mode Live Activity
 /// Defines the static and dynamic content shown on lock screen and Dynamic Island
@@ -50,3 +52,4 @@ struct CookModeActivityAttributes: ActivityAttributes {
     /// Time when cooking session started
     var sessionStartTime: Date
 }
+#endif

--- a/Cauldron/Core/Services/CookModeCoordinator.swift
+++ b/Cauldron/Core/Services/CookModeCoordinator.swift
@@ -7,8 +7,11 @@
 
 import Foundation
 import SwiftUI
-import ActivityKit
 import os
+
+#if canImport(ActivityKit) && !targetEnvironment(macCatalyst)
+import ActivityKit
+#endif
 
 /// Coordinates the persistent cook mode session across the app
 @MainActor
@@ -48,7 +51,9 @@ class CookModeCoordinator {
     private let storageKey = "activeCookSession"
 
     // Live Activity support
+    #if canImport(ActivityKit) && !targetEnvironment(macCatalyst)
     private var currentActivity: Activity<CookModeActivityAttributes>?
+    #endif
 
     // Shared UserDefaults for App Group communication
     private let sharedDefaults = UserDefaults(suiteName: "group.Nadav.Cauldron")
@@ -348,6 +353,7 @@ class CookModeCoordinator {
     // MARK: - Live Activity Methods
 
     private func startLiveActivity() async {
+        #if canImport(ActivityKit) && !targetEnvironment(macCatalyst)
         guard let recipe = currentRecipe,
               ActivityAuthorizationInfo().areActivitiesEnabled else {
             return
@@ -385,9 +391,11 @@ class CookModeCoordinator {
         } catch {
             AppLogger.general.error("❌ Failed to start Live Activity: \(error.localizedDescription)")
         }
+        #endif
     }
 
     private func updateLiveActivity() async {
+        #if canImport(ActivityKit) && !targetEnvironment(macCatalyst)
         guard let activity = currentActivity,
               let _ = currentRecipe else {
             return
@@ -428,9 +436,11 @@ class CookModeCoordinator {
         } catch {
             AppLogger.general.error("❌ Failed to update Live Activity: \(error.localizedDescription)")
         }
+        #endif
     }
 
     private func endLiveActivity() async {
+        #if canImport(ActivityKit) && !targetEnvironment(macCatalyst)
         guard let activity = currentActivity else { return }
 
         await activity.end(
@@ -440,6 +450,7 @@ class CookModeCoordinator {
 
         currentActivity = nil
         AppLogger.general.info("🛑 Ended Live Activity")
+        #endif
     }
 
     /// Update Live Activity when timers change

--- a/Cauldron/Features/Settings/WhatsNewView.swift
+++ b/Cauldron/Features/Settings/WhatsNewView.swift
@@ -30,7 +30,7 @@ struct WhatsNewView: View {
                             .font(.largeTitle)
                             .fontWeight(.bold)
 
-                        Text("Fresh upgrades for your kitchen ritual.")
+                        Text("Major upgrades just dropped!")
                             .font(.subheadline)
                             .foregroundColor(.secondary)
                             .multilineTextAlignment(.center)
@@ -38,22 +38,28 @@ struct WhatsNewView: View {
 
                     VStack(alignment: .leading, spacing: 18) {
                         FeatureRow(
-                            symbol: "app.badge.fill",
+                            symbol: "wand.and.stars.inverse",
                             color: .orange,
-                            title: "New App Icons",
-                            detail: "Invite friends to unlock new looks, then pick your favorite in Profile."
+                            title: "Model-Based Recipe Parser",
+                            detail: "Imports now use a model-backed parser for more reliable ingredient, step, and metadata extraction."
                         )
                         FeatureRow(
-                            symbol: "tag.fill",
-                            color: .pink,
-                            title: "Referral Codes",
-                            detail: "Share your code to connect instantly and earn rewards together."
+                            symbol: "person.3.fill",
+                            color: .green,
+                            title: "Invite Links and Better Referrals",
+                            detail: "Invite behavior was improved with more reliable link handling and smoother referral onboarding."
                         )
                         FeatureRow(
-                            symbol: "crown.fill",
-                            color: .yellow,
-                            title: "Cauldron Tiers",
-                            detail: "Cook more recipes to level up and unlock perks over time."
+                            symbol: "ipad",
+                            color: .indigo,
+                            title: "New iPad and Mac Apps",
+                            detail: "The brand new Cauldron iPad and Mac app is out, with layout and navigation optimizations across core recipe and collection screens."
+                        )
+                        FeatureRow(
+                            symbol: "square.and.arrow.up.fill",
+                            color: .red,
+                            title: "New Share Extension",
+                            detail: "Click share then Cauldron while browsing the web or any app to send your recipes right to Cauldron!"
                         )
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Summary
- bump MARKETING_VERSION across app, widget, share-extension, and test targets to 1.3
- gate ActivityKit/LTA code behind Catalyst-safe checks so the dedicated SwiftUI Mac app can build
- refresh What’s New copy for the model-based parser and multi-platform experience plus add AGENTS.md guidance
Testing
- Not run (not requested)