### PR TITLE
[codex] fix imported recipe detail horizontal overflow

### DIFF
--- a/Cauldron/Features/Library/Components/RecipeIngredientsSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeIngredientsSection.swift
@@ -67,6 +67,9 @@ private struct IngredientRow: View {
                 .font(.body)
                 .lineLimit(nil)
                 .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .layoutPriority(1)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 2)

--- a/Cauldron/Features/Library/Components/RecipeNotesSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeNotesSection.swift
@@ -22,12 +22,21 @@ struct RecipeNotesSection: View {
                     .font(.body)
                     .foregroundColor(.secondary)
                     .tint(.cauldronOrange)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 Text(notes)
                     .font(.body)
                     .foregroundColor(.secondary)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .cardStyle()
     }

--- a/Cauldron/Features/Library/Components/RecipeStepsSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeStepsSection.swift
@@ -78,6 +78,9 @@ private struct StepRow: View {
                     .font(.body)
                     .lineLimit(nil)
                     .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .layoutPriority(1)
 
                 if let timer = step.timers.first {
                     Button {

--- a/Cauldron/Features/Library/RecipeDetailView.swift
+++ b/Cauldron/Features/Library/RecipeDetailView.swift
@@ -210,6 +210,7 @@ struct RecipeDetailView: View {
                             compactRecipeContent
                         }
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .onAppear {
                     if let stepIndex = highlightedStepIndex {


### PR DESCRIPTION
## Summary
Imported recipes could render content wider than the screen in `RecipeDetailView`, especially after opening a recipe that included long imported text (notably source URLs appended to notes).

## User Impact
On recipe detail, parts of the content could extend beyond the visible width, causing a horizontal overflow effect and making sections look misaligned or clipped.

## Root Cause
The detail `ScrollView` content stack did not explicitly lock to the available width, and long imported multiline text in notes/ingredients/steps did not consistently receive enough wrapping/compression guidance. Imported recipes commonly include long `Source: <url>` lines in notes, which made this path much easier to trigger.

## Fix
This PR applies a focused layout hardening in recipe detail components:

- Constrain the main `RecipeDetailView` scroll content container to `maxWidth: .infinity` with leading alignment.
- In `RecipeNotesSection`, enforce multiline wrapping and width alignment for both attributed and plain text notes.
- In `RecipeIngredientsSection`, enforce multiline wrapping and width alignment for ingredient text with higher layout priority.
- In `RecipeStepsSection`, enforce multiline wrapping and width alignment for step text with higher layout priority.

No product behavior or parser logic was changed; this is a presentation/layout fix only.

## Validation
- Built successfully with:
  - `xcodebuild build -scheme Cauldron -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug CODE_SIGNING_ALLOWED=NO`
- Confirmed this branch contains only the 4 intended files and no local visionOS work.
