### PR TITLE
UI polish: Liquid Glass, warm/serif identity, zoom transitions, Friends rework

### DIFF
--- a/Cauldron/CauldronApp.swift
+++ b/Cauldron/CauldronApp.swift
@@ -167,7 +167,10 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         // Match navigation titles to the app's serif section headers.
-        Self.configureNavigationBarAppearance()
+        // Skipped under tests (no UI host); still applied in QA/preview + production.
+        if !RuntimeEnvironment.isRunningTests {
+            Self.configureNavigationBarAppearance()
+        }
 
         if RuntimeEnvironment.isRunningTests || RuntimeEnvironment.isSimulatorQAMode {
             return true

--- a/Cauldron/CauldronApp.swift
+++ b/Cauldron/CauldronApp.swift
@@ -137,10 +137,38 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         ExternalShareURLClassifier.isExternalShareURL(url)
     }
 
+    /// Render navigation titles in the system serif (New York), matching the
+    /// app's serif section headers, while keeping the default (Liquid Glass)
+    /// nav-bar background.
+    static func configureNavigationBarAppearance() {
+        func serifFont(_ textStyle: UIFont.TextStyle) -> UIFont {
+            let base = UIFont.preferredFont(forTextStyle: textStyle)
+            var descriptor = base.fontDescriptor
+            if let serif = descriptor.withDesign(.serif) { descriptor = serif }
+            if let bold = descriptor.withSymbolicTraits(descriptor.symbolicTraits.union(.traitBold)) {
+                descriptor = bold
+            }
+            return UIFont(descriptor: descriptor, size: base.pointSize)
+        }
+
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithDefaultBackground()
+        appearance.largeTitleTextAttributes = [.font: serifFont(.largeTitle)]
+        appearance.titleTextAttributes = [.font: serifFont(.headline)]
+
+        let navBar = UINavigationBar.appearance()
+        navBar.standardAppearance = appearance
+        navBar.scrollEdgeAppearance = appearance
+        navBar.compactAppearance = appearance
+    }
+
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        // Match navigation titles to the app's serif section headers.
+        Self.configureNavigationBarAppearance()
+
         if RuntimeEnvironment.isRunningTests || RuntimeEnvironment.isSimulatorQAMode {
             return true
         }

--- a/Cauldron/Core/Components/RecipeCardView.swift
+++ b/Cauldron/Core/Components/RecipeCardView.swift
@@ -152,7 +152,7 @@ struct RecipeCardView: View {
                         }
                         .padding(.horizontal, 8)
                         .padding(.vertical, 5)
-                        .glassEffect(.regular, in: Capsule())
+                        .glassEffect(.clear, in: Capsule())
                     }
 
                     Spacer()
@@ -163,7 +163,7 @@ struct RecipeCardView: View {
                             .font(.system(size: 12, weight: .semibold))
                             .foregroundColor(tier.color)
                             .padding(6)
-                            .glassEffect(.regular, in: Circle())
+                            .glassEffect(.clear, in: Circle())
                     }
                 }
                 .padding(8)
@@ -186,7 +186,7 @@ struct RecipeCardView: View {
                             .font(.caption)
                             .foregroundStyle(.yellow)
                             .padding(6)
-                            .glassEffect(.regular, in: Circle())
+                            .glassEffect(.clear, in: Circle())
                             .padding(8)
                     }
                 }

--- a/Cauldron/Core/Components/RecipeCardView.swift
+++ b/Cauldron/Core/Components/RecipeCardView.swift
@@ -27,6 +27,9 @@ import SwiftUI
 /// ```
 struct RecipeCardView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    /// Whether the top of the image is light (→ use dark overlay text). Updated
+    /// from the loaded image's luminance so over-image labels stay legible.
+    @State private var overlayPrefersDarkText = false
 
     let recipe: Recipe
     let dependencies: DependencyContainer
@@ -84,8 +87,10 @@ struct RecipeCardView: View {
         VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
             // Image with contextual overlays
             ZStack {
-                RecipeImageView(recipe: recipe, recipeImageService: dependencies.recipeImageService)
-                    .frame(width: cardWidth, height: cardHeight)
+                RecipeImageView(recipe: recipe, recipeImageService: dependencies.recipeImageService) { luminance in
+                    overlayPrefersDarkText = luminance > 0.6
+                }
+                .frame(width: cardWidth, height: cardHeight)
 
                 if isSharedRecipe {
                     // Shared recipe: show creator overlay
@@ -149,6 +154,7 @@ struct RecipeCardView: View {
                                 .font(.caption2)
                                 .fontWeight(.medium)
                                 .lineLimit(1)
+                                .foregroundStyle(overlayPrefersDarkText ? .black : .white)
                         }
                         .padding(.horizontal, 8)
                         .padding(.vertical, 5)

--- a/Cauldron/Core/Components/RecipeCardView.swift
+++ b/Cauldron/Core/Components/RecipeCardView.swift
@@ -137,58 +137,62 @@ struct RecipeCardView: View {
 
     /// Overlay for shared recipes - shows creator info and tier badge
     private var sharedRecipeOverlay: some View {
-        VStack {
-            HStack(alignment: .top) {
-                // Creator info (top left)
-                if let creator = sharedBy {
-                    HStack(spacing: 6) {
-                        ProfileAvatar(user: creator, size: 24, dependencies: dependencies)
+        GlassEffectContainer(spacing: 2) {
+            VStack {
+                HStack(alignment: .top) {
+                    // Creator info (top left)
+                    if let creator = sharedBy {
+                        HStack(spacing: 6) {
+                            ProfileAvatar(user: creator, size: 24, dependencies: dependencies)
 
-                        Text(creator.displayName)
-                            .font(.caption2)
-                            .fontWeight(.medium)
-                            .lineLimit(1)
+                            Text(creator.displayName)
+                                .font(.caption2)
+                                .fontWeight(.medium)
+                                .lineLimit(1)
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .glassEffect(.regular, in: Capsule())
                     }
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 5)
-                    .glassEffect(.regular, in: Capsule())
+
+                    Spacer()
+
+                    // Tier badge (top right)
+                    if let tier = creatorTier, tier != .apprentice {
+                        Image(systemName: tier.icon)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(tier.color)
+                            .padding(6)
+                            .glassEffect(.regular, in: Circle())
+                    }
                 }
+                .padding(8)
 
                 Spacer()
-
-                // Tier badge (top right)
-                if let tier = creatorTier, tier != .apprentice {
-                    Image(systemName: tier.icon)
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundColor(tier.color)
-                        .padding(6)
-                        .glassEffect(.regular, in: Circle())
-                }
             }
-            .padding(8)
-
-            Spacer()
         }
     }
 
     /// Overlay for own recipes - shows favorite star
     private var ownRecipeOverlay: some View {
-        VStack {
-            HStack {
-                Spacer()
+        GlassEffectContainer(spacing: 2) {
+            VStack {
+                HStack {
+                    Spacer()
 
-                // Favorite indicator (top-right)
-                if recipe.isFavorite {
-                    Image(systemName: "star.fill")
-                        .font(.caption)
-                        .foregroundStyle(.yellow)
-                        .padding(6)
-                        .glassEffect(.regular, in: Circle())
-                        .padding(8)
+                    // Favorite indicator (top-right)
+                    if recipe.isFavorite {
+                        Image(systemName: "star.fill")
+                            .font(.caption)
+                            .foregroundStyle(.yellow)
+                            .padding(6)
+                            .glassEffect(.regular, in: Circle())
+                            .padding(8)
+                    }
                 }
-            }
 
-            Spacer()
+                Spacer()
+            }
         }
     }
 

--- a/Cauldron/Core/Components/RecipeCardView.swift
+++ b/Cauldron/Core/Components/RecipeCardView.swift
@@ -151,7 +151,7 @@ struct RecipeCardView: View {
                     }
                     .padding(.horizontal, 8)
                     .padding(.vertical, 5)
-                    .background(.ultraThinMaterial, in: Capsule())
+                    .glassEffect(.regular, in: Capsule())
                 }
 
                 Spacer()
@@ -162,7 +162,7 @@ struct RecipeCardView: View {
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundColor(tier.color)
                         .padding(6)
-                        .background(Circle().fill(.ultraThinMaterial))
+                        .glassEffect(.regular, in: Circle())
                 }
             }
             .padding(8)
@@ -183,7 +183,7 @@ struct RecipeCardView: View {
                         .font(.caption)
                         .foregroundStyle(.yellow)
                         .padding(6)
-                        .background(Circle().fill(.ultraThinMaterial))
+                        .glassEffect(.regular, in: Circle())
                         .padding(8)
                 }
             }

--- a/Cauldron/Core/Components/RecipeImageView.swift
+++ b/Cauldron/Core/Components/RecipeImageView.swift
@@ -6,6 +6,50 @@
 //
 
 import SwiftUI
+import CoreImage
+
+/// Shared CoreImage context for cheap luminance sampling (creating one per call
+/// is expensive).
+private enum RecipeLuminance {
+    static let context = CIContext(options: [.workingColorSpace: NSNull()])
+}
+
+extension UIImage {
+    /// Average perceived luminance (0 = dark, 1 = light) of the image's top
+    /// region — where overlay chips sit — so callers can pick legible
+    /// white/black foreground colors. Returns nil if it can't be sampled.
+    func topRegionLuminance() -> Double? {
+        guard let cg = cgImage else { return nil }
+        let ciImage = CIImage(cgImage: cg)
+        let extent = ciImage.extent
+        guard extent.height > 0 else { return nil }
+        // Top 35% (CIImage origin is bottom-left, so the top is the high-y band).
+        let topExtent = CGRect(
+            x: extent.minX,
+            y: extent.maxY - extent.height * 0.35,
+            width: extent.width,
+            height: extent.height * 0.35
+        )
+        guard let filter = CIFilter(name: "CIAreaAverage", parameters: [
+            kCIInputImageKey: ciImage,
+            kCIInputExtentKey: CIVector(cgRect: topExtent)
+        ]), let output = filter.outputImage else { return nil }
+
+        var bitmap = [UInt8](repeating: 0, count: 4)
+        RecipeLuminance.context.render(
+            output,
+            toBitmap: &bitmap,
+            rowBytes: 4,
+            bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+            format: .RGBA8,
+            colorSpace: CGColorSpaceCreateDeviceRGB()
+        )
+        let r = Double(bitmap[0]) / 255.0
+        let g = Double(bitmap[1]) / 255.0
+        let b = Double(bitmap[2]) / 255.0
+        return 0.299 * r + 0.587 * g + 0.114 * b
+    }
+}
 
 private enum RecipeImageLoadingPipeline {
     static func initialCachedImage(recipeId: UUID?, variant: String) -> UIImage? {
@@ -67,6 +111,9 @@ struct RecipeImageView: View {
     let recipeImageService: RecipeImageService
     let recipeId: UUID?
     let ownerId: UUID?
+    /// Optional: reports the loaded image's average luminance (0 = dark, 1 =
+    /// light) so overlays can pick legible (white/black) foreground colors.
+    var onLuminance: ((Double) -> Void)? = nil
 
     @Environment(\.displayScale) private var displayScale
     @State private var loadedImage: UIImage?
@@ -92,7 +139,8 @@ struct RecipeImageView: View {
         showPlaceholderText: Bool = false,
         recipeImageService: RecipeImageService,
         recipeId: UUID? = nil,
-        ownerId: UUID? = nil
+        ownerId: UUID? = nil,
+        onLuminance: ((Double) -> Void)? = nil
     ) {
         self.imageURL = imageURL
         self.size = size
@@ -100,6 +148,7 @@ struct RecipeImageView: View {
         self.recipeImageService = recipeImageService
         self.recipeId = recipeId
         self.ownerId = ownerId
+        self.onLuminance = onLuminance
 
         // Initialize with cache to avoid placeholder flicker on back-navigation.
         if let cachedImage = RecipeImageLoadingPipeline.initialCachedImage(recipeId: recipeId, variant: cacheVariant) {
@@ -152,6 +201,9 @@ struct RecipeImageView: View {
                 loadedImage: &loadedImage,
                 imageOpacity: &imageOpacity
             )
+            if let onLuminance, let luminance = image.topRegionLuminance() {
+                onLuminance(luminance)
+            }
         case .failure:
             break
         }
@@ -282,8 +334,8 @@ extension RecipeImageView {
     }
 
     /// Create a card-sized image view from a Recipe object (with CloudKit fallback)
-    init(recipe: Recipe, recipeImageService: RecipeImageService) {
-        self.init(imageURL: recipe.imageURL, size: .card, showPlaceholderText: false, recipeImageService: recipeImageService, recipeId: recipe.id, ownerId: recipe.ownerId)
+    init(recipe: Recipe, recipeImageService: RecipeImageService, onLuminance: ((Double) -> Void)? = nil) {
+        self.init(imageURL: recipe.imageURL, size: .card, showPlaceholderText: false, recipeImageService: recipeImageService, recipeId: recipe.id, ownerId: recipe.ownerId, onLuminance: onLuminance)
     }
 
     /// Create a thumbnail-sized image view from a Recipe object (with CloudKit fallback)

--- a/Cauldron/Core/Components/TagView.swift
+++ b/Cauldron/Core/Components/TagView.swift
@@ -48,13 +48,14 @@ struct TagView: View {
         HStack(spacing: 6) {
             if let emoji = emoji {
                 Text(emoji)
-                    .font(.caption)
+                    .font(.caption2)
             }
             
             Text(displayName)
-                .font(.caption)
+                .font(.caption2)
                 .fontWeight(.medium)
-            
+                .lineLimit(1)
+
             if let onRemove = onRemove {
                 Button(action: onRemove) {
                     Image(systemName: "xmark")

--- a/Cauldron/Core/DesignSystem/DesignTokens.swift
+++ b/Cauldron/Core/DesignSystem/DesignTokens.swift
@@ -152,7 +152,7 @@ extension View {
     /// a `GlassEffectContainer` so they render and clip correctly (a standalone
     /// glass element in a scroll view can otherwise float above sibling content).
     func glassCard(cornerRadius: CGFloat = Theme.Radius.large) -> some View {
-        glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        glassEffect(.clear, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
     }
 }
 

--- a/Cauldron/Core/DesignSystem/DesignTokens.swift
+++ b/Cauldron/Core/DesignSystem/DesignTokens.swift
@@ -135,22 +135,24 @@ extension View {
 
     /// Replace a scroll/list's default system canvas with the warm app
     /// background, so cards (`appSurface`) sit on the editorial paper tone.
+    ///
+    /// The warm color sits *behind* the scroll view as a ZStack sibling rather
+    /// than as a `.background` on the scroll itself — applying an
+    /// `ignoresSafeArea` background directly to a scroll view shrinks its safe
+    /// area and stops large navigation titles from collapsing to inline on scroll.
     func warmCanvas() -> some View {
-        scrollContentBackground(.hidden)
-            .background(Color.appBackground.ignoresSafeArea())
+        ZStack {
+            Color.appBackground.ignoresSafeArea()
+            scrollContentBackground(.hidden)
+        }
     }
 
-    /// Frosted glass card surface (translucent material + hairline stroke).
-    /// Use for content cards that should feel light and layered over the warm
-    /// canvas — recipe sections, feed headers, etc.
+    /// Native Liquid Glass card surface. Use for content cards that should feel
+    /// light and layered over the warm canvas — recipe sections, feed headers,
+    /// etc. For several glass cards on one screen, wrap them in a
+    /// `GlassEffectContainer` so they blend and render efficiently.
     func glassCard(cornerRadius: CGFloat = Theme.Radius.large) -> some View {
-        self
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .strokeBorder(Color.appSeparator.opacity(0.6), lineWidth: 0.5)
-            )
-            .shadow(color: .black.opacity(0.06), radius: 8, x: 0, y: 3)
+        glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
     }
 }
 

--- a/Cauldron/Core/DesignSystem/DesignTokens.swift
+++ b/Cauldron/Core/DesignSystem/DesignTokens.swift
@@ -139,6 +139,19 @@ extension View {
         scrollContentBackground(.hidden)
             .background(Color.appBackground.ignoresSafeArea())
     }
+
+    /// Frosted glass card surface (translucent material + hairline stroke).
+    /// Use for content cards that should feel light and layered over the warm
+    /// canvas — recipe sections, feed headers, etc.
+    func glassCard(cornerRadius: CGFloat = Theme.Radius.large) -> some View {
+        self
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(Color.appSeparator.opacity(0.6), lineWidth: 0.5)
+            )
+            .shadow(color: .black.opacity(0.06), radius: 8, x: 0, y: 3)
+    }
 }
 
 /// Button style that scales and dims slightly while pressed.

--- a/Cauldron/Core/DesignSystem/DesignTokens.swift
+++ b/Cauldron/Core/DesignSystem/DesignTokens.swift
@@ -147,21 +147,12 @@ extension View {
         }
     }
 
-    /// Frosted material card surface for *scrolling content* (recipe sections,
-    /// feed headers, etc.).
-    ///
-    /// NOTE: This intentionally uses `.regularMaterial`, not `.glassEffect`.
-    /// Liquid Glass is the floating chrome material — it blurs and sits *above*
-    /// content, so on a scrolling content card it visually floats over the rows
-    /// beneath it. Reserve `.glassEffect` / `.buttonStyle(.glass)` for chrome
-    /// and controls; use material for content surfaces.
+    /// Native Liquid Glass card surface. Apply to content cards (recipe
+    /// sections, feed headers). When several appear on one screen, wrap them in
+    /// a `GlassEffectContainer` so they render and clip correctly (a standalone
+    /// glass element in a scroll view can otherwise float above sibling content).
     func glassCard(cornerRadius: CGFloat = Theme.Radius.large) -> some View {
-        self
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .strokeBorder(Color.appSeparator.opacity(0.5), lineWidth: 0.5)
-            )
+        glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
     }
 }
 

--- a/Cauldron/Core/DesignSystem/DesignTokens.swift
+++ b/Cauldron/Core/DesignSystem/DesignTokens.swift
@@ -147,10 +147,12 @@ extension View {
         }
     }
 
-    /// Native Liquid Glass card surface. Apply to content cards (recipe
-    /// sections, feed headers). When several appear on one screen, wrap them in
-    /// a `GlassEffectContainer` so they render and clip correctly (a standalone
-    /// glass element in a scroll view can otherwise float above sibling content).
+    /// Native Liquid Glass card surface.
+    ///
+    /// IMPORTANT: wrap groups of glass cards in a `GlassEffectContainer` (with
+    /// `spacing` smaller than the gap between cards so they don't merge). The
+    /// container is what keeps the glass clipped to the scroll view — a bare
+    /// `glassEffect` in a scroll view composites over the nav/tab bars.
     func glassCard(cornerRadius: CGFloat = Theme.Radius.large) -> some View {
         glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
     }

--- a/Cauldron/Core/DesignSystem/DesignTokens.swift
+++ b/Cauldron/Core/DesignSystem/DesignTokens.swift
@@ -147,12 +147,21 @@ extension View {
         }
     }
 
-    /// Native Liquid Glass card surface. Use for content cards that should feel
-    /// light and layered over the warm canvas — recipe sections, feed headers,
-    /// etc. For several glass cards on one screen, wrap them in a
-    /// `GlassEffectContainer` so they blend and render efficiently.
+    /// Frosted material card surface for *scrolling content* (recipe sections,
+    /// feed headers, etc.).
+    ///
+    /// NOTE: This intentionally uses `.regularMaterial`, not `.glassEffect`.
+    /// Liquid Glass is the floating chrome material — it blurs and sits *above*
+    /// content, so on a scrolling content card it visually floats over the rows
+    /// beneath it. Reserve `.glassEffect` / `.buttonStyle(.glass)` for chrome
+    /// and controls; use material for content surfaces.
     func glassCard(cornerRadius: CGFloat = Theme.Radius.large) -> some View {
-        glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        self
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(Color.appSeparator.opacity(0.5), lineWidth: 0.5)
+            )
     }
 }
 

--- a/Cauldron/Core/DesignSystem/DesignTokens.swift
+++ b/Cauldron/Core/DesignSystem/DesignTokens.swift
@@ -152,7 +152,7 @@ extension View {
     /// a `GlassEffectContainer` so they render and clip correctly (a standalone
     /// glass element in a scroll view can otherwise float above sibling content).
     func glassCard(cornerRadius: CGFloat = Theme.Radius.large) -> some View {
-        glassEffect(.clear, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
     }
 }
 

--- a/Cauldron/Features/Collections/CollectionCardView.swift
+++ b/Cauldron/Features/Collections/CollectionCardView.swift
@@ -130,6 +130,8 @@ struct CollectionCardView: View {
     let recipeImageSources: [CollectionRecipeImageSource]
     let preferredWidth: CGFloat?
     let dependencies: DependencyContainer?
+    /// Optional owner shown as a creator tag over the cover (for friends' collections).
+    let owner: User?
     @State private var customCoverImage: UIImage?
     @State private var loadedCoverKey: String?
     @State private var isLoadingImage = false
@@ -139,6 +141,7 @@ struct CollectionCardView: View {
         recipeImages: [URL?],
         recipeImageSources: [CollectionRecipeImageSource]? = nil,
         preferredWidth: CGFloat? = 200,
+        owner: User? = nil,
         dependencies: DependencyContainer? = nil
     ) {
         self.collection = collection
@@ -147,6 +150,7 @@ struct CollectionCardView: View {
             CollectionRecipeImageSource(imageURL: $0)
         }
         self.preferredWidth = preferredWidth
+        self.owner = owner
         self.dependencies = dependencies
     }
 
@@ -172,6 +176,24 @@ struct CollectionCardView: View {
                     RoundedRectangle(cornerRadius: 12)
                         .stroke(collectionColor.opacity(0.2), lineWidth: 1)
                 )
+                .overlay(alignment: .topLeading) {
+                    if let owner, let dependencies {
+                        GlassEffectContainer(spacing: 2) {
+                            HStack(spacing: 6) {
+                                ProfileAvatar(user: owner, size: 22, dependencies: dependencies)
+                                Text(owner.displayName)
+                                    .font(.caption2)
+                                    .fontWeight(.medium)
+                                    .lineLimit(1)
+                                    .foregroundStyle(.white)
+                            }
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 5)
+                            .glassEffect(.clear, in: Capsule())
+                        }
+                        .padding(8)
+                    }
+                }
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {

--- a/Cauldron/Features/Collections/CollectionCardView.swift
+++ b/Cauldron/Features/Collections/CollectionCardView.swift
@@ -135,6 +135,10 @@ struct CollectionCardView: View {
     @State private var customCoverImage: UIImage?
     @State private var loadedCoverKey: String?
     @State private var isLoadingImage = false
+    /// Owner-tag text adapts to the cover's top luminance (white over dark
+    /// covers, black over light ones). Defaults to white for gradient/collage
+    /// covers, which read well with white text.
+    @State private var overlayPrefersDarkText = false
 
     init(
         collection: Collection,
@@ -185,7 +189,7 @@ struct CollectionCardView: View {
                                     .font(.caption2)
                                     .fontWeight(.medium)
                                     .lineLimit(1)
-                                    .foregroundStyle(.white)
+                                    .foregroundStyle(overlayPrefersDarkText ? .black : .white)
                             }
                             .padding(.horizontal, 8)
                             .padding(.vertical, 5)
@@ -283,6 +287,9 @@ struct CollectionCardView: View {
                 customCoverImage = image
             }
             loadedCoverKey = customCoverTaskID
+            if let luminance = image.topRegionLuminance() {
+                overlayPrefersDarkText = luminance > 0.6
+            }
         } else {
             customCoverImage = nil
             loadedCoverKey = nil

--- a/Cauldron/Features/Collections/CollectionsListView.swift
+++ b/Cauldron/Features/Collections/CollectionsListView.swift
@@ -49,7 +49,7 @@ struct CollectionsListView: View {
         }
         .warmCanvas()
         .navigationTitle("Collections")
-        .navigationBarTitleDisplayMode(.large)
+        .toolbarTitleDisplayMode(.inlineLarge)
         .searchable(text: $viewModel.searchText, prompt: "Search collections")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {

--- a/Cauldron/Features/Collections/CollectionsListView.swift
+++ b/Cauldron/Features/Collections/CollectionsListView.swift
@@ -12,6 +12,7 @@ struct CollectionsListView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var viewModel: CollectionsListViewModel
     @State private var showingCreateSheet = false
+    @Namespace private var cardTransition
 
     init(dependencies: DependencyContainer) {
         _viewModel = State(initialValue: CollectionsListViewModel(dependencies: dependencies))
@@ -119,7 +120,11 @@ struct CollectionsListView: View {
 
                 LazyVGrid(columns: gridColumns, spacing: Theme.Spacing.sm) {
                     ForEach(collections) { collection in
-                        NavigationLink(destination: CollectionDetailView(collection: collection, dependencies: dependencies)) {
+                        let transitionID = "collection-\(collection.id.uuidString)"
+                        NavigationLink {
+                            CollectionDetailView(collection: collection, dependencies: dependencies)
+                                .navigationTransition(.zoom(sourceID: transitionID, in: cardTransition))
+                        } label: {
                             CollectionCardView(
                                 collection: collection,
                                 recipeImages: viewModel.recipeImages(for: collection),
@@ -129,6 +134,7 @@ struct CollectionsListView: View {
                             )
                         }
                         .buttonStyle(PlainButtonStyle())
+                        .matchedTransitionSource(id: transitionID, in: cardTransition)
                         .contextMenu {
                             Button(role: .destructive) {
                                 Task {

--- a/Cauldron/Features/Cook/CookTabView.swift
+++ b/Cauldron/Features/Cook/CookTabView.swift
@@ -408,7 +408,11 @@ struct CookTabView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: Theme.Spacing.md) {
                         ForEach(collections.prefix(10)) { collection in
-                            NavigationLink(destination: CollectionDetailView(collection: collection, dependencies: viewModel.dependencies)) {
+                            let collectionTransitionID = "collection-\(collection.id.uuidString)"
+                            NavigationLink {
+                                CollectionDetailView(collection: collection, dependencies: viewModel.dependencies)
+                                    .navigationTransition(.zoom(sourceID: collectionTransitionID, in: recipeTransition))
+                            } label: {
                                 CollectionCardView(
                                     collection: collection,
                                     recipeImages: viewModel.getRecipeImages(for: collection),
@@ -417,6 +421,7 @@ struct CookTabView: View {
                                 )
                             }
                             .buttonStyle(PressableScaleStyle())
+                            .matchedTransitionSource(id: collectionTransitionID, in: recipeTransition)
                         }
                     }
                     .padding(.horizontal, Theme.Spacing.md)

--- a/Cauldron/Features/Cook/CookTabView.swift
+++ b/Cauldron/Features/Cook/CookTabView.swift
@@ -25,6 +25,7 @@ struct CookTabView: View {
     @State private var isAIAvailable = false
     @State private var shouldSpotlightRecentlyAdded = false
     @State private var recentlyAddedSpotlightTask: Task<Void, Never>?
+    @Namespace private var recipeTransition
     private let recentlyAddedSectionID = "cookRecentlyAddedSection"
 
     init(dependencies: DependencyContainer, preloadedData: PreloadedRecipeData?) {
@@ -293,14 +294,19 @@ struct CookTabView: View {
     }
 
     /// Standard horizontal carousel of the user's own recipe cards, with context menu + preview.
+    /// Cards zoom into the detail screen for a continuous, delightful transition.
     private func recipeCarousel(_ recipes: [Recipe], limit: Int = 10) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: Theme.Spacing.md) {
                 ForEach(recipes.prefix(limit)) { recipe in
-                    NavigationLink(destination: RecipeDetailView(recipe: recipe, dependencies: viewModel.dependencies)) {
+                    NavigationLink {
+                        RecipeDetailView(recipe: recipe, dependencies: viewModel.dependencies)
+                            .navigationTransition(.zoom(sourceID: recipe.id, in: recipeTransition))
+                    } label: {
                         RecipeCardView(recipe: recipe, dependencies: viewModel.dependencies)
                     }
                     .buttonStyle(PressableScaleStyle())
+                    .matchedTransitionSource(id: recipe.id, in: recipeTransition)
                     .contextMenu {
                         recipeContextMenu(for: recipe)
                     } preview: {

--- a/Cauldron/Features/Cook/CookTabView.swift
+++ b/Cauldron/Features/Cook/CookTabView.swift
@@ -117,8 +117,7 @@ struct CookTabView: View {
                 }
                 .padding(.vertical)
             }
-            .scrollContentBackground(.hidden)
-            .background(Color.appBackground.ignoresSafeArea())
+            .warmCanvas()
             .navigationTitle("Cook")
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
@@ -295,18 +294,21 @@ struct CookTabView: View {
 
     /// Standard horizontal carousel of the user's own recipe cards, with context menu + preview.
     /// Cards zoom into the detail screen for a continuous, delightful transition.
-    private func recipeCarousel(_ recipes: [Recipe], limit: Int = 10) -> some View {
+    /// `section` keeps the zoom source id unique when the same recipe appears in
+    /// more than one section, so the animation always originates from the tapped card.
+    private func recipeCarousel(_ recipes: [Recipe], section: String, limit: Int = 10) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: Theme.Spacing.md) {
                 ForEach(recipes.prefix(limit)) { recipe in
+                    let transitionID = "\(section)-\(recipe.id.uuidString)"
                     NavigationLink {
                         RecipeDetailView(recipe: recipe, dependencies: viewModel.dependencies)
-                            .navigationTransition(.zoom(sourceID: recipe.id, in: recipeTransition))
+                            .navigationTransition(.zoom(sourceID: transitionID, in: recipeTransition))
                     } label: {
                         RecipeCardView(recipe: recipe, dependencies: viewModel.dependencies)
                     }
                     .buttonStyle(PressableScaleStyle())
-                    .matchedTransitionSource(id: recipe.id, in: recipeTransition)
+                    .matchedTransitionSource(id: transitionID, in: recipeTransition)
                     .contextMenu {
                         recipeContextMenu(for: recipe)
                     } preview: {
@@ -330,7 +332,7 @@ struct CookTabView: View {
                 systemImage: "clock.badge.plus",
                 seeAll: AnyView(AllRecipesListView(recipes: viewModel.recentlyAddedRecipes, dependencies: viewModel.dependencies))
             )
-            recipeCarousel(viewModel.recentlyAddedRecipes)
+            recipeCarousel(viewModel.recentlyAddedRecipes, section: "recentlyAdded")
         }
     }
 
@@ -341,7 +343,7 @@ struct CookTabView: View {
                 systemImage: "clock.arrow.circlepath",
                 seeAll: AnyView(RecentlyCookedListView(recipes: viewModel.recentlyCookedRecipes, dependencies: viewModel.dependencies))
             )
-            recipeCarousel(viewModel.recentlyCookedRecipes)
+            recipeCarousel(viewModel.recentlyCookedRecipes, section: "recentlyCooked")
         }
     }
 
@@ -353,7 +355,7 @@ struct CookTabView: View {
                 iconColor: .yellow,
                 seeAll: AnyView(FavoritesListView(recipes: viewModel.favoriteRecipes, dependencies: viewModel.dependencies))
             )
-            recipeCarousel(viewModel.favoriteRecipes)
+            recipeCarousel(viewModel.favoriteRecipes, section: "favorites")
         }
     }
 
@@ -427,21 +429,21 @@ struct CookTabView: View {
     private var quickRecipesSection: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
             cookSectionHeader("Quick & Easy", systemImage: "timer")
-            recipeCarousel(viewModel.quickRecipes)
+            recipeCarousel(viewModel.quickRecipes, section: "quick")
         }
     }
 
     private var onRotationSection: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
             cookSectionHeader("On Rotation", systemImage: "arrow.triangle.2.circlepath")
-            recipeCarousel(viewModel.onRotationRecipes)
+            recipeCarousel(viewModel.onRotationRecipes, section: "onRotation")
         }
     }
 
     private var forgottenFavoritesSection: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
             cookSectionHeader("Rediscover Favorites", systemImage: "sparkles")
-            recipeCarousel(viewModel.forgottenFavorites)
+            recipeCarousel(viewModel.forgottenFavorites, section: "rediscover")
         }
     }
 
@@ -456,7 +458,7 @@ struct CookTabView: View {
             if viewModel.allRecipes.isEmpty {
                 emptyState
             } else {
-                recipeCarousel(viewModel.allRecipes)
+                recipeCarousel(viewModel.allRecipes, section: "allRecipes")
             }
         }
     }
@@ -468,7 +470,7 @@ struct CookTabView: View {
                 systemImage: "tag.fill",
                 seeAll: AnyView(ExploreTagView(tag: Tag(name: tag), dependencies: viewModel.dependencies))
             )
-            recipeCarousel(recipes, limit: recipes.count)
+            recipeCarousel(recipes, section: "tag-\(tag)", limit: recipes.count)
         }
     }
     

--- a/Cauldron/Features/Cook/CookTabView.swift
+++ b/Cauldron/Features/Cook/CookTabView.swift
@@ -121,15 +121,6 @@ struct CookTabView: View {
             .navigationTitle("Cook")
             .toolbarTitleDisplayMode(.inlineLarge)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    if let user = currentUserSession.currentUser {
-                        Button {
-                            showingProfileSheet = true
-                        } label: {
-                            ProfileAvatar(user: user, size: 32, dependencies: viewModel.dependencies)
-                        }
-                    }
-                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     AddRecipeMenu(
                         dependencies: viewModel.dependencies,
@@ -138,6 +129,15 @@ struct CookTabView: View {
                         showingImporter: $showingImporter,
                         showingCollectionForm: $showingCollectionForm
                     )
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if let user = currentUserSession.currentUser {
+                        Button {
+                            showingProfileSheet = true
+                        } label: {
+                            ProfileAvatar(user: user, size: 30, dependencies: viewModel.dependencies)
+                        }
+                    }
                 }
             }
             .sheet(isPresented: $showingImporter, onDismiss: {

--- a/Cauldron/Features/Cook/CookTabView.swift
+++ b/Cauldron/Features/Cook/CookTabView.swift
@@ -119,6 +119,7 @@ struct CookTabView: View {
             }
             .warmCanvas()
             .navigationTitle("Cook")
+            .toolbarTitleDisplayMode(.inlineLarge)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     if let user = currentUserSession.currentUser {

--- a/Cauldron/Features/CookMode/CookModeView.swift
+++ b/Cauldron/Features/CookMode/CookModeView.swift
@@ -402,6 +402,8 @@ struct CookModeView: View {
                             Image(systemName: isChecked ? "checkmark.circle.fill" : "circle")
                                 .foregroundStyle(isChecked ? Color.cauldronOrange : .secondary)
                                 .font(.body)
+                                .contentTransition(.symbolEffect(.replace))
+                                .symbolEffect(.bounce, value: isChecked)
 
                             Text(ingredient.displayString)
                                 .font(.subheadline)

--- a/Cauldron/Features/Groceries/GroceriesView.swift
+++ b/Cauldron/Features/Groceries/GroceriesView.swift
@@ -37,6 +37,7 @@ struct GroceriesView: View {
             }
             .background(Color.appBackground.ignoresSafeArea())
             .navigationTitle("Groceries")
+            .toolbarTitleDisplayMode(.inlineLarge)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     if let user = currentUserSession.currentUser {

--- a/Cauldron/Features/Groceries/GroceriesView.swift
+++ b/Cauldron/Features/Groceries/GroceriesView.swift
@@ -39,16 +39,6 @@ struct GroceriesView: View {
             .navigationTitle("Groceries")
             .toolbarTitleDisplayMode(.inlineLarge)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    if let user = currentUserSession.currentUser {
-                        Button {
-                            showingProfileSheet = true
-                        } label: {
-                            ProfileAvatar(user: user, size: 32, dependencies: viewModel.dependencies)
-                        }
-                    }
-                }
-
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Menu {
                         Picker("Sort By", selection: $viewMode) {
@@ -82,6 +72,16 @@ struct GroceriesView: View {
                         showingAddItem = true
                     } label: {
                         Image(systemName: "plus")
+                    }
+                }
+
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if let user = currentUserSession.currentUser {
+                        Button {
+                            showingProfileSheet = true
+                        } label: {
+                            ProfileAvatar(user: user, size: 30, dependencies: viewModel.dependencies)
+                        }
                     }
                 }
             }

--- a/Cauldron/Features/Groceries/GroceriesView.swift
+++ b/Cauldron/Features/Groceries/GroceriesView.swift
@@ -216,6 +216,8 @@ struct GroceriesView: View {
             HStack {
                 Image(systemName: item.isChecked ? "checkmark.circle.fill" : "circle")
                     .foregroundColor(item.isChecked ? .cauldronOrange : .secondary)
+                    .contentTransition(.symbolEffect(.replace))
+                    .symbolEffect(.bounce, value: item.isChecked)
 
                 VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
                     Text(item.name)

--- a/Cauldron/Features/Library/Components/RecipeHeaderSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeHeaderSection.swift
@@ -138,7 +138,7 @@ struct RecipeHeaderSection: View {
             }
         }
         .padding()
-        .cardStyle()
+        .glassCard()
     }
 
     @ViewBuilder

--- a/Cauldron/Features/Library/Components/RecipeHeaderSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeHeaderSection.swift
@@ -151,7 +151,7 @@ struct RecipeHeaderSection: View {
                     .font(.title3.weight(.semibold))
                     .frame(width: 36, height: 36)
                     .foregroundStyle(localIsFavorite ? .yellow : .secondary)
-                    .background(Color.appSurface, in: Circle())
+                    .background(.ultraThinMaterial, in: Circle())
             }
             .accessibilityLabel(localIsFavorite ? "Remove Favorite" : "Favorite")
         } else if hasOwnedCopy {
@@ -212,7 +212,7 @@ struct RecipeHeaderSection: View {
         .foregroundColor(.secondary)
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
-        .background(Color.appSurface, in: Capsule())
+        .background(.ultraThinMaterial, in: Capsule())
     }
 
     private func sourceNavigationPill(user: User, text: String) -> some View {
@@ -237,7 +237,7 @@ struct RecipeHeaderSection: View {
             .foregroundColor(.secondary)
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
-            .background(Color.appSurface, in: Capsule())
+            .background(.ultraThinMaterial, in: Capsule())
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)

--- a/Cauldron/Features/Library/Components/RecipeIngredientsSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeIngredientsSection.swift
@@ -31,7 +31,7 @@ struct RecipeIngredientsSection: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
-        .cardStyle()
+        .glassCard()
     }
 
     private var groupedIngredients: [String: [Ingredient]] {

--- a/Cauldron/Features/Library/Components/RecipeNotesSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeNotesSection.swift
@@ -40,7 +40,7 @@ struct RecipeNotesSection: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
-        .cardStyle()
+        .glassCard()
     }
 
     private func makeLinksClickable(_ text: String) -> AttributedString? {

--- a/Cauldron/Features/Library/Components/RecipeNutritionSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeNutritionSection.swift
@@ -30,7 +30,7 @@ struct RecipeNutritionSection: View {
             }
         }
         .padding()
-        .cardStyle()
+        .glassCard()
     }
 }
 

--- a/Cauldron/Features/Library/Components/RecipeRelatedSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeRelatedSection.swift
@@ -31,7 +31,7 @@ struct RecipeRelatedSection: View {
             }
         }
         .padding()
-        .cardStyle()
+        .glassCard()
     }
 }
 

--- a/Cauldron/Features/Library/Components/RecipeStepsSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeStepsSection.swift
@@ -37,7 +37,7 @@ struct RecipeStepsSection: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
-        .cardStyle()
+        .glassCard()
     }
 
     private var groupedSteps: [String: [CookStep]] {

--- a/Cauldron/Features/Library/RecipeDetailView.swift
+++ b/Cauldron/Features/Library/RecipeDetailView.swift
@@ -159,13 +159,15 @@ struct RecipeDetailView: View {
 
     @ViewBuilder
     private var compactRecipeContent: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            recipeHeaderSection
-            notesSection
-            ingredientsSection
-            stepsSection
-            nutritionSection
-            relatedSection
+        GlassEffectContainer(spacing: 20) {
+            VStack(alignment: .leading, spacing: 20) {
+                recipeHeaderSection
+                notesSection
+                ingredientsSection
+                stepsSection
+                nutritionSection
+                relatedSection
+            }
         }
         .padding(.horizontal, 16)
         .padding(.top, hasHeroImage ? 0 : 20)
@@ -174,23 +176,25 @@ struct RecipeDetailView: View {
 
     @ViewBuilder
     private var regularRecipeContent: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            recipeHeaderSection
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            HStack(alignment: .top, spacing: 20) {
-                VStack(alignment: .leading, spacing: 20) {
-                    ingredientsSection
-                    notesSection
-                }
-                .frame(maxWidth: 430, alignment: .leading)
-
-                stepsSection
+        GlassEffectContainer(spacing: 20) {
+            VStack(alignment: .leading, spacing: 20) {
+                recipeHeaderSection
                     .frame(maxWidth: .infinity, alignment: .leading)
-            }
 
-            nutritionSection
-            relatedSection
+                HStack(alignment: .top, spacing: 20) {
+                    VStack(alignment: .leading, spacing: 20) {
+                        ingredientsSection
+                        notesSection
+                    }
+                    .frame(maxWidth: 430, alignment: .leading)
+
+                    stepsSection
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                nutritionSection
+                relatedSection
+            }
         }
         .padding(.horizontal, 20)
         .padding(.top, hasHeroImage ? 0 : 20)

--- a/Cauldron/Features/Library/RecipeDetailView.swift
+++ b/Cauldron/Features/Library/RecipeDetailView.swift
@@ -248,14 +248,16 @@ struct RecipeDetailView: View {
                             .renderingMode(.template)
                             .resizable()
                             .scaledToFit()
-                            .frame(width: 22, height: 22)
+                            .frame(width: 26, height: 26)
 
                         Text("Cook")
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
+                            .font(.headline)
                     }
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 4)
                 }
                 .buttonStyle(.glassProminent)
+                .controlSize(.extraLarge)
                 .tint(.cauldronOrange)
                 .padding(.trailing, 20)
                 .padding(.bottom, 16)

--- a/Cauldron/Features/Library/RecipeDetailView.swift
+++ b/Cauldron/Features/Library/RecipeDetailView.swift
@@ -159,15 +159,13 @@ struct RecipeDetailView: View {
 
     @ViewBuilder
     private var compactRecipeContent: some View {
-        GlassEffectContainer(spacing: 20) {
-            VStack(alignment: .leading, spacing: 20) {
-                recipeHeaderSection
-                notesSection
-                ingredientsSection
-                stepsSection
-                nutritionSection
-                relatedSection
-            }
+        VStack(alignment: .leading, spacing: 20) {
+            recipeHeaderSection
+            notesSection
+            ingredientsSection
+            stepsSection
+            nutritionSection
+            relatedSection
         }
         .padding(.horizontal, 16)
         .padding(.top, hasHeroImage ? 0 : 20)
@@ -176,25 +174,23 @@ struct RecipeDetailView: View {
 
     @ViewBuilder
     private var regularRecipeContent: some View {
-        GlassEffectContainer(spacing: 20) {
-            VStack(alignment: .leading, spacing: 20) {
-                recipeHeaderSection
-                    .frame(maxWidth: .infinity, alignment: .leading)
+        VStack(alignment: .leading, spacing: 20) {
+            recipeHeaderSection
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                HStack(alignment: .top, spacing: 20) {
-                    VStack(alignment: .leading, spacing: 20) {
-                        ingredientsSection
-                        notesSection
-                    }
-                    .frame(maxWidth: 430, alignment: .leading)
-
-                    stepsSection
-                        .frame(maxWidth: .infinity, alignment: .leading)
+            HStack(alignment: .top, spacing: 20) {
+                VStack(alignment: .leading, spacing: 20) {
+                    ingredientsSection
+                    notesSection
                 }
+                .frame(maxWidth: 430, alignment: .leading)
 
-                nutritionSection
-                relatedSection
+                stepsSection
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
+
+            nutritionSection
+            relatedSection
         }
         .padding(.horizontal, 20)
         .padding(.top, hasHeroImage ? 0 : 20)
@@ -248,17 +244,15 @@ struct RecipeDetailView: View {
                             .renderingMode(.template)
                             .resizable()
                             .scaledToFit()
-                            .frame(width: 24, height: 24)
+                            .frame(width: 22, height: 22)
 
                         Text("Cook")
                             .font(.subheadline)
                             .fontWeight(.semibold)
                     }
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 12)
-                    .glassEffect(.regular.tint(.orange).interactive(), in: Capsule())
                 }
+                .buttonStyle(.glassProminent)
+                .tint(.cauldronOrange)
                 .padding(.trailing, 20)
                 .padding(.bottom, 16)
             }

--- a/Cauldron/Features/Library/RecipeDetailView.swift
+++ b/Cauldron/Features/Library/RecipeDetailView.swift
@@ -159,7 +159,7 @@ struct RecipeDetailView: View {
 
     @ViewBuilder
     private var compactRecipeContent: some View {
-        GlassEffectContainer(spacing: 20) {
+        GlassEffectContainer(spacing: 2) {
             VStack(alignment: .leading, spacing: 20) {
                 recipeHeaderSection
                 notesSection
@@ -176,7 +176,7 @@ struct RecipeDetailView: View {
 
     @ViewBuilder
     private var regularRecipeContent: some View {
-        GlassEffectContainer(spacing: 20) {
+        GlassEffectContainer(spacing: 2) {
             VStack(alignment: .leading, spacing: 20) {
                 recipeHeaderSection
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Cauldron/Features/Library/RecipeDetailView.swift
+++ b/Cauldron/Features/Library/RecipeDetailView.swift
@@ -259,6 +259,7 @@ struct RecipeDetailView: View {
                 .padding(.bottom, 16)
             }
         }
+        .background(Color.appBackground.ignoresSafeArea())
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .refreshable {

--- a/Cauldron/Features/Search/ExploreTagView.swift
+++ b/Cauldron/Features/Search/ExploreTagView.swift
@@ -648,7 +648,7 @@ struct TagRecipesListView: View {
     var body: some View {
         contentView
         .navigationTitle("All Recipes")
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(.large)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 RecipeLayoutToolbarButton(resolvedMode: resolvedRecipeLayoutMode) { mode in
@@ -713,7 +713,7 @@ struct TagFriendRecipesListView: View {
     var body: some View {
         contentView
         .navigationTitle("From Friends")
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(.large)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 RecipeLayoutToolbarButton(resolvedMode: resolvedRecipeLayoutMode) { mode in
@@ -784,7 +784,7 @@ struct TagPublicRecipesListView: View {
     var body: some View {
         contentView
         .navigationTitle("Community Recipes")
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(.large)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 RecipeLayoutToolbarButton(resolvedMode: resolvedRecipeLayoutMode) { mode in

--- a/Cauldron/Features/Search/SearchTabView.swift
+++ b/Cauldron/Features/Search/SearchTabView.swift
@@ -274,10 +274,9 @@ struct SearchTabView: View {
                                     Spacer()
                                 }
                                 .padding(Theme.Spacing.sm)
-                                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
-                                        .strokeBorder(category.color.opacity(0.25), lineWidth: 0.5)
+                                .glassEffect(
+                                    .regular.tint(category.color.opacity(0.35)),
+                                    in: RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
                                 )
                             }
                             .buttonStyle(PressableScaleStyle())

--- a/Cauldron/Features/Search/SearchTabView.swift
+++ b/Cauldron/Features/Search/SearchTabView.swift
@@ -250,36 +250,38 @@ struct SearchTabView: View {
                     Text(section.rawValue)
                         .font(.title3)
                         .fontWeight(.bold)
-                    
-                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: Theme.Spacing.sm)], spacing: Theme.Spacing.sm) {
-                        ForEach(RecipeCategory.all(in: section)) { category in
-                            Button {
-                                navigationPath.append(Tag(name: category.tagValue))
-                            } label: {
-                                HStack(spacing: Theme.Spacing.sm) {
-                                    // Icon Container
-                                    ZStack {
-                                        Circle()
-                                            .fill(category.color.opacity(0.15))
-                                            .frame(width: 40, height: 40)
-                                        Text(category.emoji)
-                                            .font(.title3)
+
+                    GlassEffectContainer(spacing: 2) {
+                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: Theme.Spacing.sm)], spacing: Theme.Spacing.sm) {
+                            ForEach(RecipeCategory.all(in: section)) { category in
+                                Button {
+                                    navigationPath.append(Tag(name: category.tagValue))
+                                } label: {
+                                    HStack(spacing: Theme.Spacing.sm) {
+                                        // Icon Container
+                                        ZStack {
+                                            Circle()
+                                                .fill(category.color.opacity(0.15))
+                                                .frame(width: 40, height: 40)
+                                            Text(category.emoji)
+                                                .font(.title3)
+                                        }
+
+                                        Text(category.displayName)
+                                            .font(.body)
+                                            .fontWeight(.medium)
+                                            .foregroundColor(.primary)
+
+                                        Spacer()
                                     }
-
-                                    Text(category.displayName)
-                                        .font(.body)
-                                        .fontWeight(.medium)
-                                        .foregroundColor(.primary)
-
-                                    Spacer()
+                                    .padding(Theme.Spacing.sm)
+                                    .glassEffect(
+                                        .regular.tint(category.color.opacity(0.35)),
+                                        in: RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+                                    )
                                 }
-                                .padding(Theme.Spacing.sm)
-                                .glassEffect(
-                                    .regular.tint(category.color.opacity(0.35)),
-                                    in: RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
-                                )
+                                .buttonStyle(PressableScaleStyle())
                             }
-                            .buttonStyle(PressableScaleStyle())
                         }
                     }
                 }

--- a/Cauldron/Features/Search/SearchTabView.swift
+++ b/Cauldron/Features/Search/SearchTabView.swift
@@ -16,6 +16,7 @@ struct SearchTabView: View {
     @State private var searchText = ""
     @State private var searchMode: SearchMode = .recipes
     @State private var showingProfileSheet = false
+    @Namespace private var recipeTransition
 
     enum SearchMode: String, CaseIterable {
         case recipes = "Recipes"
@@ -93,6 +94,7 @@ struct SearchTabView: View {
                 }
                 .navigationDestination(for: Recipe.self) { recipe in
                     RecipeDetailView(recipe: recipe, dependencies: viewModel.dependencies)
+                        .navigationTransition(.zoom(sourceID: recipe.id, in: recipeTransition))
                 }
                 .navigationDestination(for: User.self) { user in
                     UserProfileView(user: user, dependencies: viewModel.dependencies)
@@ -320,6 +322,7 @@ struct SearchTabView: View {
                             SearchRecipeGroupRow(group: group, dependencies: viewModel.dependencies)
                         }
                         .buttonStyle(PressableScaleStyle())
+                        .matchedTransitionSource(id: group.primaryRecipe.id, in: recipeTransition)
                     }
                 }
             }

--- a/Cauldron/Features/Search/SearchTabView.swift
+++ b/Cauldron/Features/Search/SearchTabView.swift
@@ -276,7 +276,7 @@ struct SearchTabView: View {
                                     }
                                     .padding(Theme.Spacing.sm)
                                     .glassEffect(
-                                        .regular.tint(category.color.opacity(0.35)),
+                                        .regular.tint(category.color.opacity(0.35)).interactive(),
                                         in: RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
                                     )
                                 }
@@ -399,14 +399,14 @@ struct SearchTabView: View {
     private var peopleSearchView: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
             if searchText.isEmpty {
-                // Show friends list if available, otherwise show empty state
-                if !viewModel.friends.isEmpty {
-                    Text("Your Friends")
+                // Recommendations only (no friends list)
+                if !viewModel.recommendedUsers.isEmpty {
+                    Text("Suggested for You")
                         .font(.headline)
                         .foregroundColor(.secondary)
                         .padding(.top, 8)
-                    
-                    ForEach(viewModel.friends) { user in
+
+                    ForEach(viewModel.recommendedUsers) { user in
                         Button {
                             navigationPath.append(user)
                         } label: {
@@ -417,36 +417,16 @@ struct SearchTabView: View {
                         }
                         .buttonStyle(PressableScaleStyle())
                     }
-                    
-                    // Recommended Users (Friends of Friends)
-                    if !viewModel.recommendedUsers.isEmpty {
-                        Text("Suggested for You")
-                            .font(.headline)
-                            .foregroundColor(.secondary)
-                            .padding(.top, 24)
-                        
-                        ForEach(viewModel.recommendedUsers) { user in
-                            Button {
-                                navigationPath.append(user)
-                            } label: {
-                                UserSearchRowView(
-                                    user: user,
-                                    viewModel: viewModel
-                                )
-                            }
-                            .buttonStyle(PressableScaleStyle())
-                        }
-                    }
                 } else {
                     VStack(spacing: Theme.Spacing.md) {
                         Image(systemName: "person.2")
                             .font(.system(size: 48))
                             .foregroundColor(.secondary)
-                        
+
                         Text("Search for People")
                             .font(.headline)
                             .foregroundColor(.secondary)
-                            
+
                         Text("Find friends to share recipes with")
                             .font(.subheadline)
                             .foregroundColor(.secondary)

--- a/Cauldron/Features/Search/SearchTabView.swift
+++ b/Cauldron/Features/Search/SearchTabView.swift
@@ -88,6 +88,7 @@ struct SearchTabView: View {
         NavigationStack(path: $navigationPath) {
             searchContent
                 .navigationTitle("Search")
+                .toolbarTitleDisplayMode(.inlineLarge)
                 .toolbar { searchToolbar }
                 .refreshable {
                     await viewModel.loadData(forceRefreshPublicRecipes: true)
@@ -115,6 +116,7 @@ struct SearchTabView: View {
         NavigationSplitView {
             searchContent
                 .navigationTitle("Search")
+                .toolbarTitleDisplayMode(.inlineLarge)
                 .toolbar { searchToolbar }
                 .navigationSplitViewColumnWidth(min: 320, ideal: 360, max: 420)
                 .refreshable {

--- a/Cauldron/Features/Search/SearchTabView.swift
+++ b/Cauldron/Features/Search/SearchTabView.swift
@@ -213,7 +213,7 @@ struct SearchTabView: View {
 
     @ToolbarContentBuilder
     private var searchToolbar: some ToolbarContent {
-        ToolbarItem(placement: .navigationBarLeading) {
+        ToolbarItem(placement: .navigationBarTrailing) {
             if let user = currentUserSession.currentUser {
                 Button {
                     showingProfileSheet = true

--- a/Cauldron/Features/Search/SearchTabView.swift
+++ b/Cauldron/Features/Search/SearchTabView.swift
@@ -270,9 +270,12 @@ struct SearchTabView: View {
 
                                     Spacer()
                                 }
-                                .padding(8)
-                                .background(Color(.secondarySystemGroupedBackground))
-                                .cornerRadius(12)
+                                .padding(Theme.Spacing.sm)
+                                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
+                                        .strokeBorder(category.color.opacity(0.25), lineWidth: 0.5)
+                                )
                             }
                             .buttonStyle(PressableScaleStyle())
                         }
@@ -379,10 +382,13 @@ struct SearchTabView: View {
         .foregroundStyle(isActive ? Color.cauldronOrange : Color.primary)
         .padding(.horizontal, Theme.Spacing.sm)
         .padding(.vertical, Theme.Spacing.xs)
-        .background(
-            (isActive ? Color.cauldronOrange.opacity(0.15) : Color.appSurface),
-            in: Capsule()
-        )
+        .background {
+            if isActive {
+                Capsule().fill(Color.cauldronOrange.opacity(0.15))
+            } else {
+                Capsule().fill(.ultraThinMaterial)
+            }
+        }
     }
     
     private var peopleSearchView: some View {

--- a/Cauldron/Features/Search/SearchTabView.swift
+++ b/Cauldron/Features/Search/SearchTabView.swift
@@ -190,9 +190,8 @@ struct SearchTabView: View {
                 }
                 .padding()
             }
-            .scrollContentBackground(.hidden)
         }
-        .background(Color.appBackground.ignoresSafeArea())
+        .warmCanvas()
     }
 
     private var splitDetailPlaceholder: some View {

--- a/Cauldron/Features/Search/SearchTabViewModel.swift
+++ b/Cauldron/Features/Search/SearchTabViewModel.swift
@@ -66,7 +66,7 @@ enum RecipeSortOrder: String, CaseIterable, Identifiable {
     var recipesByTag: [String: [Recipe]] = [:]
     var recipeSearchResults: [SearchRecipeGroup] = []
     var peopleSearchResults: [User] = []
-    var friends: [User] = []
+    var friends: [User] = [] // Used for friend-saver social proof in recipe search ranking
     var isLoading = false
     var isLoadingPeople = false
     var connections: [Connection] = [] // Derived from connectionManager
@@ -229,7 +229,7 @@ enum RecipeSortOrder: String, CaseIterable, Identifiable {
         // Update local connections array from manager
         connections = dependencies.connectionManager.connections.values.map { $0.connection }
 
-        // Load friends details
+        // Load friends details (used for friend-saver social proof in search ranking)
         await loadFriends()
     }
 
@@ -237,19 +237,19 @@ enum RecipeSortOrder: String, CaseIterable, Identifiable {
         let friendIds = connections
             .filter { $0.isAccepted }
             .compactMap { $0.otherUserId(currentUserId: currentUserId) }
-            
+
         guard !friendIds.isEmpty else {
             friends = []
             return
         }
-        
+
         do {
             friends = try await dependencies.sharingService.getUsers(byIds: friendIds)
         } catch {
             AppLogger.general.error("Failed to load friends: \(error.localizedDescription)")
         }
     }
-    
+
     var recommendedUsers: [User] = []
     
     func loadRecommendations() async {

--- a/Cauldron/Features/Settings/OnboardingView.swift
+++ b/Cauldron/Features/Settings/OnboardingView.swift
@@ -288,11 +288,9 @@ struct OnboardingView: View {
                                     .fontWeight(.semibold)
                             }
                         }
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 24)
-                        .padding(.vertical, 14)
-                        .glassEffect(.regular.tint(isValid ? .orange : .gray).interactive(), in: Capsule())
                     }
+                    .buttonStyle(.glassProminent)
+                    .tint(isValid ? .cauldronOrange : .gray)
                     .disabled(!isValid || isCreating)
                     .padding(.bottom, 32)
                 }

--- a/Cauldron/Features/Sharing/AllFriendsListViews.swift
+++ b/Cauldron/Features/Sharing/AllFriendsListViews.swift
@@ -30,7 +30,7 @@ struct AllFriendsRecipesListView: View {
     var body: some View {
         contentView
         .navigationTitle(title)
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(.large)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 RecipeLayoutToolbarButton(resolvedMode: resolvedRecipeLayoutMode) { mode in
@@ -120,7 +120,7 @@ struct AllFriendsCollectionsListView: View {
             .padding(.vertical, 8)
         }
         .navigationTitle("Friends' Collections")
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(.large)
     }
 
     private var gridColumns: [GridItem] {

--- a/Cauldron/Features/Sharing/ConnectionsView.swift
+++ b/Cauldron/Features/Sharing/ConnectionsView.swift
@@ -150,7 +150,7 @@ struct ConnectionRequestCard: View {
             NavigationLink {
                 UserProfileView(user: user, dependencies: dependencies)
             } label: {
-                ProfileAvatar(user: user, size: 48, dependencies: dependencies)
+                ProfileAvatar(user: user, size: 40, dependencies: dependencies)
             }
             .buttonStyle(.plain)
 
@@ -207,12 +207,11 @@ struct ConnectionRequestCard: View {
                 }
             }
         }
-        .padding(12)
-        .background(Color.cauldronSecondaryBackground)
-        .cornerRadius(12)
-        .shadow(color: .black.opacity(0.06), radius: 4, x: 0, y: 2)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.cauldronOrange.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         .padding(.horizontal, 16)
-        .padding(.vertical, 4)
+        .padding(.vertical, 2)
     }
 }
 

--- a/Cauldron/Features/Sharing/FriendsTabComponents.swift
+++ b/Cauldron/Features/Sharing/FriendsTabComponents.swift
@@ -96,7 +96,8 @@ struct SectionHeader: View {
             Spacer()
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 16)
+        .padding(.top, 12)
+        .padding(.bottom, 4)
     }
 }
 

--- a/Cauldron/Features/Sharing/FriendsTabComponents.swift
+++ b/Cauldron/Features/Sharing/FriendsTabComponents.swift
@@ -105,6 +105,7 @@ struct SectionHeader: View {
 
 struct ConnectionsInlineView: View {
     @State private var viewModel: ConnectionsViewModel
+    @State private var showingRequests = false
     let dependencies: DependencyContainer
     var onAddFriend: (() -> Void)?
 
@@ -141,95 +142,71 @@ struct ConnectionsInlineView: View {
         .accessibilityLabel("Add friends")
     }
 
+    private var hasAnyConnectionsActivity: Bool {
+        !viewModel.connections.isEmpty || !viewModel.receivedRequests.isEmpty || !viewModel.sentRequests.isEmpty
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            // Pending requests (most important - shown first)
-            if !viewModel.receivedRequests.isEmpty {
-                ForEach(viewModel.receivedRequests.prefix(3), id: \.id) { connection in
-                    if let user = viewModel.usersMap[connection.fromUserId] {
-                        ConnectionRequestCard(
-                            user: user,
-                            connection: connection,
-                            dependencies: dependencies,
-                            onAccept: {
-                                await viewModel.acceptRequest(connection)
-                            },
-                            onReject: {
-                                await viewModel.rejectRequest(connection)
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            // Top row: requests badge (left) + See All (right)
+            if !viewModel.receivedRequests.isEmpty || !viewModel.connections.isEmpty {
+                HStack(spacing: Theme.Spacing.sm) {
+                    if !viewModel.receivedRequests.isEmpty {
+                        Button {
+                            showingRequests = true
+                        } label: {
+                            HStack(spacing: 5) {
+                                Image(systemName: "person.crop.circle.badge.plus")
+                                Text("\(viewModel.receivedRequests.count) \(viewModel.receivedRequests.count == 1 ? "request" : "requests")")
+                                    .fontWeight(.semibold)
                             }
-                        )
-                    }
-                }
-
-                if viewModel.receivedRequests.count > 3 {
-                    NavigationLink(destination: ConnectionsView(dependencies: dependencies)) {
-                        Text("View \(viewModel.receivedRequests.count - 3) more requests")
                             .font(.caption)
-                            .foregroundColor(.cauldronOrange)
-                            .padding(.vertical, 8)
-                            .padding(.horizontal, 16)
-                    }
-                }
-            }
-
-            // Friends display
-            if viewModel.connections.isEmpty && viewModel.receivedRequests.isEmpty && viewModel.sentRequests.isEmpty {
-                // Empty state
-                VStack(spacing: Theme.Spacing.sm) {
-                    Image(systemName: "person.2.circle")
-                        .font(.system(size: 40))
-                        .foregroundColor(.gray.opacity(0.5))
-
-                    Text("No friends yet")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-
-                    // Removed redundant link to SearchTabView
-                    Text("Find people to add")
-                        .font(.caption)
-                        .foregroundColor(.cauldronOrange)
-                        .onTapGesture {
-                            if let onAddFriend {
-                                onAddFriend()
-                            } else {
-                                NotificationCenter.default.post(name: NSNotification.Name("SwitchToSearchTab"), object: nil)
-                            }
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(Color.cauldronOrange, in: Capsule())
                         }
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 20)
-            } else {
-                // Horizontal scrolling friends
-                if !viewModel.connections.isEmpty {
-                    HStack {
-                        Spacer()
+                        .buttonStyle(PressableScaleStyle())
+                        .accessibilityLabel("\(viewModel.receivedRequests.count) friend requests, tap to review")
+                    }
 
+                    Spacer()
+
+                    if !viewModel.connections.isEmpty {
                         NavigationLink(destination: ConnectionsView(dependencies: dependencies)) {
                             Text("See All")
                                 .font(.subheadline)
                                 .foregroundColor(.cauldronOrange)
                         }
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.top, 4)
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+            }
 
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: Theme.Spacing.md) {
-                            if onAddFriend != nil {
-                                addFriendTile
-                            }
-                            ForEach(viewModel.connections.prefix(10), id: \.id) { connection in
-                                if let otherUserId = connection.otherUserId(currentUserId: viewModel.currentUserId),
-                                   let user = viewModel.usersMap[otherUserId] {
-                                    ConnectionAvatarCard(user: user, dependencies: dependencies)
-                                }
+            // Content
+            if !hasAnyConnectionsActivity {
+                emptyConnectionsState
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: Theme.Spacing.md) {
+                        if onAddFriend != nil {
+                            addFriendTile
+                        }
+                        ForEach(viewModel.connections.prefix(10), id: \.id) { connection in
+                            if let otherUserId = connection.otherUserId(currentUserId: viewModel.currentUserId),
+                               let user = viewModel.usersMap[otherUserId] {
+                                ConnectionAvatarCard(user: user, dependencies: dependencies)
                             }
                         }
-                        .padding(.horizontal, 16)
-                        .padding(.bottom, 8)
                     }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
                 }
             }
+        }
+        .sheet(isPresented: $showingRequests) {
+            requestsSheet
         }
         .task {
             await viewModel.loadConnections()
@@ -239,5 +216,68 @@ struct ConnectionsInlineView: View {
                 await viewModel.loadConnections(forceRefresh: true)
             }
         }
+    }
+
+    private var emptyConnectionsState: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "person.2.circle")
+                .font(.system(size: 36))
+                .foregroundColor(.gray.opacity(0.5))
+
+            Text("No friends yet")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            Text("Find people to add")
+                .font(.caption)
+                .foregroundColor(.cauldronOrange)
+                .onTapGesture {
+                    if let onAddFriend {
+                        onAddFriend()
+                    } else {
+                        NotificationCenter.default.post(name: NSNotification.Name("SwitchToSearchTab"), object: nil)
+                    }
+                }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
+    }
+
+    private var requestsSheet: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: Theme.Spacing.sm) {
+                    if viewModel.receivedRequests.isEmpty {
+                        ContentUnavailableView(
+                            "No Pending Requests",
+                            systemImage: "person.crop.circle.badge.checkmark",
+                            description: Text("You're all caught up.")
+                        )
+                        .padding(.top, 60)
+                    } else {
+                        ForEach(viewModel.receivedRequests, id: \.id) { connection in
+                            if let user = viewModel.usersMap[connection.fromUserId] {
+                                ConnectionRequestCard(
+                                    user: user,
+                                    connection: connection,
+                                    dependencies: dependencies,
+                                    onAccept: { await viewModel.acceptRequest(connection) },
+                                    onReject: { await viewModel.rejectRequest(connection) }
+                                )
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical)
+            }
+            .navigationTitle("Friend Requests")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { showingRequests = false }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
     }
 }

--- a/Cauldron/Features/Sharing/FriendsTabComponents.swift
+++ b/Cauldron/Features/Sharing/FriendsTabComponents.swift
@@ -105,7 +105,6 @@ struct SectionHeader: View {
 
 struct ConnectionsInlineView: View {
     @State private var viewModel: ConnectionsViewModel
-    @State private var showingRequests = false
     let dependencies: DependencyContainer
     var onAddFriend: (() -> Void)?
 
@@ -122,24 +121,36 @@ struct ConnectionsInlineView: View {
             onAddFriend?()
         } label: {
             VStack(spacing: 6) {
-                ZStack {
+                ZStack(alignment: .topTrailing) {
                     Circle()
                         .strokeBorder(
                             Color.cauldronOrange.opacity(0.8),
                             style: StrokeStyle(lineWidth: 2, dash: [5, 4])
                         )
                         .frame(width: 56, height: 56)
-                    Image(systemName: "plus")
-                        .font(.title3.weight(.semibold))
-                        .foregroundColor(.cauldronOrange)
+                        .overlay(
+                            Image(systemName: "plus")
+                                .font(.title3.weight(.semibold))
+                                .foregroundColor(.cauldronOrange)
+                        )
+
+                    // Pending-request count badge
+                    if !viewModel.receivedRequests.isEmpty {
+                        Text("\(viewModel.receivedRequests.count)")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(.white)
+                            .padding(5)
+                            .background(Color.red, in: Circle())
+                            .offset(x: 4, y: -4)
+                    }
                 }
-                Text("Add")
+                Text(viewModel.receivedRequests.isEmpty ? "Add" : "Requests")
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
         }
         .buttonStyle(PressableScaleStyle())
-        .accessibilityLabel("Add friends")
+        .accessibilityLabel(viewModel.receivedRequests.isEmpty ? "Add friends" : "\(viewModel.receivedRequests.count) friend requests and add friends")
     }
 
     private var hasAnyConnectionsActivity: Bool {
@@ -148,36 +159,14 @@ struct ConnectionsInlineView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
-            // Top row: requests badge (left) + See All (right)
-            if !viewModel.receivedRequests.isEmpty || !viewModel.connections.isEmpty {
-                HStack(spacing: Theme.Spacing.sm) {
-                    if !viewModel.receivedRequests.isEmpty {
-                        Button {
-                            showingRequests = true
-                        } label: {
-                            HStack(spacing: 5) {
-                                Image(systemName: "person.crop.circle.badge.plus")
-                                Text("\(viewModel.receivedRequests.count) \(viewModel.receivedRequests.count == 1 ? "request" : "requests")")
-                                    .fontWeight(.semibold)
-                            }
-                            .font(.caption)
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
-                            .background(Color.cauldronOrange, in: Capsule())
-                        }
-                        .buttonStyle(PressableScaleStyle())
-                        .accessibilityLabel("\(viewModel.receivedRequests.count) friend requests, tap to review")
-                    }
-
+            // Top row: See All (right)
+            if !viewModel.connections.isEmpty {
+                HStack {
                     Spacer()
-
-                    if !viewModel.connections.isEmpty {
-                        NavigationLink(destination: ConnectionsView(dependencies: dependencies)) {
-                            Text("See All")
-                                .font(.subheadline)
-                                .foregroundColor(.cauldronOrange)
-                        }
+                    NavigationLink(destination: ConnectionsView(dependencies: dependencies)) {
+                        Text("See All")
+                            .font(.subheadline)
+                            .foregroundColor(.cauldronOrange)
                     }
                 }
                 .padding(.horizontal, 16)
@@ -204,9 +193,6 @@ struct ConnectionsInlineView: View {
                     .padding(.vertical, 8)
                 }
             }
-        }
-        .sheet(isPresented: $showingRequests) {
-            requestsSheet
         }
         .task {
             await viewModel.loadConnections()
@@ -243,41 +229,4 @@ struct ConnectionsInlineView: View {
         .padding(.vertical, 20)
     }
 
-    private var requestsSheet: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: Theme.Spacing.sm) {
-                    if viewModel.receivedRequests.isEmpty {
-                        ContentUnavailableView(
-                            "No Pending Requests",
-                            systemImage: "person.crop.circle.badge.checkmark",
-                            description: Text("You're all caught up.")
-                        )
-                        .padding(.top, 60)
-                    } else {
-                        ForEach(viewModel.receivedRequests, id: \.id) { connection in
-                            if let user = viewModel.usersMap[connection.fromUserId] {
-                                ConnectionRequestCard(
-                                    user: user,
-                                    connection: connection,
-                                    dependencies: dependencies,
-                                    onAccept: { await viewModel.acceptRequest(connection) },
-                                    onReject: { await viewModel.rejectRequest(connection) }
-                                )
-                            }
-                        }
-                    }
-                }
-                .padding(.vertical)
-            }
-            .navigationTitle("Friend Requests")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") { showingRequests = false }
-                }
-            }
-        }
-        .presentationDetents([.medium, .large])
-    }
 }

--- a/Cauldron/Features/Sharing/FriendsTabComponents.swift
+++ b/Cauldron/Features/Sharing/FriendsTabComponents.swift
@@ -106,10 +106,39 @@ struct SectionHeader: View {
 struct ConnectionsInlineView: View {
     @State private var viewModel: ConnectionsViewModel
     let dependencies: DependencyContainer
+    var onAddFriend: (() -> Void)?
 
-    init(dependencies: DependencyContainer) {
+    init(dependencies: DependencyContainer, onAddFriend: (() -> Void)? = nil) {
         self.dependencies = dependencies
+        self.onAddFriend = onAddFriend
         _viewModel = State(initialValue: ConnectionsViewModel(dependencies: dependencies))
+    }
+
+    /// Dashed "+" tile that opens the add-friends flow, shown at the start of
+    /// the friends row (replaces the toolbar "+" button).
+    private var addFriendTile: some View {
+        Button {
+            onAddFriend?()
+        } label: {
+            VStack(spacing: 6) {
+                ZStack {
+                    Circle()
+                        .strokeBorder(
+                            Color.cauldronOrange.opacity(0.8),
+                            style: StrokeStyle(lineWidth: 2, dash: [5, 4])
+                        )
+                        .frame(width: 56, height: 56)
+                    Image(systemName: "plus")
+                        .font(.title3.weight(.semibold))
+                        .foregroundColor(.cauldronOrange)
+                }
+                Text("Add")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .buttonStyle(PressableScaleStyle())
+        .accessibilityLabel("Add friends")
     }
 
     var body: some View {
@@ -160,9 +189,11 @@ struct ConnectionsInlineView: View {
                         .font(.caption)
                         .foregroundColor(.cauldronOrange)
                         .onTapGesture {
-                            // Ideally switch tab, but for now just show text
-                            // Or use a notification to switch tab
-                            NotificationCenter.default.post(name: NSNotification.Name("SwitchToSearchTab"), object: nil)
+                            if let onAddFriend {
+                                onAddFriend()
+                            } else {
+                                NotificationCenter.default.post(name: NSNotification.Name("SwitchToSearchTab"), object: nil)
+                            }
                         }
                 }
                 .frame(maxWidth: .infinity)
@@ -184,6 +215,9 @@ struct ConnectionsInlineView: View {
 
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: Theme.Spacing.md) {
+                            if onAddFriend != nil {
+                                addFriendTile
+                            }
                             ForEach(viewModel.connections.prefix(10), id: \.id) { connection in
                                 if let otherUserId = connection.otherUserId(currentUserId: viewModel.currentUserId),
                                    let user = viewModel.usersMap[otherUserId] {

--- a/Cauldron/Features/Sharing/FriendsTabView.swift
+++ b/Cauldron/Features/Sharing/FriendsTabView.swift
@@ -271,8 +271,7 @@ struct FriendsTabView: View {
                     ConnectionsInlineView(dependencies: dependencies)
                         .padding(.bottom, 8)
                 }
-                .background(Color.cauldronSecondaryBackground)
-                .cornerRadius(16)
+                .glassCard(cornerRadius: 16)
                 .padding(.horizontal, 16)
                 .padding(.top, 12)
 

--- a/Cauldron/Features/Sharing/FriendsTabView.swift
+++ b/Cauldron/Features/Sharing/FriendsTabView.swift
@@ -189,15 +189,6 @@ struct FriendsTabView: View {
 
     @ToolbarContentBuilder
     private var friendsToolbar: some ToolbarContent {
-        ToolbarItem(placement: .navigationBarLeading) {
-            if let user = userSession.currentUser {
-                Button {
-                    showingProfileSheet = true
-                } label: {
-                    ProfileAvatar(user: user, size: 32, dependencies: dependencies)
-                }
-            }
-        }
         ToolbarItemGroup(placement: .navigationBarTrailing) {
             Button {
                 showingInviteSheet = true
@@ -209,6 +200,14 @@ struct FriendsTabView: View {
                 showingPeopleSearch = true
             } label: {
                 Image(systemName: "plus")
+            }
+
+            if let user = userSession.currentUser {
+                Button {
+                    showingProfileSheet = true
+                } label: {
+                    ProfileAvatar(user: user, size: 30, dependencies: dependencies)
+                }
             }
         }
     }

--- a/Cauldron/Features/Sharing/FriendsTabView.swift
+++ b/Cauldron/Features/Sharing/FriendsTabView.swift
@@ -196,12 +196,6 @@ struct FriendsTabView: View {
                 Label("Invite", systemImage: "gift.fill")
             }
 
-            Button {
-                showingPeopleSearch = true
-            } label: {
-                Image(systemName: "plus")
-            }
-
             if let user = userSession.currentUser {
                 Button {
                     showingProfileSheet = true
@@ -272,15 +266,13 @@ struct FriendsTabView: View {
                     VStack(spacing: 0) {
                         SectionHeader(title: "Friends", icon: "person.2.fill", color: .green)
 
-                        ConnectionsInlineView(dependencies: dependencies)
+                        ConnectionsInlineView(dependencies: dependencies, onAddFriend: { showingPeopleSearch = true })
                             .padding(.bottom, 8)
                     }
                     .glassCard(cornerRadius: 16)
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 12)
-
-                inviteInlineCard
 
                 if viewModel.isLoading {
                     ProgressView("Loading recipes...")
@@ -308,49 +300,6 @@ struct FriendsTabView: View {
             }
         }
         .background(Color.cauldronBackground.ignoresSafeArea())
-    }
-
-    private var inviteInlineCard: some View {
-        Button {
-            showingInviteSheet = true
-        } label: {
-            HStack(spacing: 12) {
-                Image(systemName: "person.badge.plus")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.cauldronOrange)
-                    .frame(width: 32, height: 32)
-                    .background(Color.cauldronOrange.opacity(0.12), in: Circle())
-
-                Text("Invite friends & unlock rewards")
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                    .foregroundColor(.primary)
-                    .lineLimit(1)
-
-                Spacer()
-
-                Image(systemName: "chevron.right")
-                    .font(.caption.weight(.semibold))
-                    .foregroundColor(.secondary)
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                LinearGradient(
-                    colors: [Color.cauldronOrange.opacity(0.12), Color.cauldronSecondaryBackground],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 16)
-                    .stroke(Color.cauldronOrange.opacity(0.28), lineWidth: 1)
-            )
-            .clipShape(.rect(cornerRadius: 16))
-        }
-        .buttonStyle(PressableScaleStyle())
-        .padding(.horizontal, 16)
     }
 
     private var emptyRecipesState: some View {

--- a/Cauldron/Features/Sharing/FriendsTabView.swift
+++ b/Cauldron/Features/Sharing/FriendsTabView.swift
@@ -25,6 +25,7 @@ struct FriendsTabView: View {
     @State private var showingPeopleSearch = false
     @State private var showingInviteSheet = false
     @State private var collectionImageCache: [UUID: [URL?]] = [:]
+    @Namespace private var recipeTransition
 
     let dependencies: DependencyContainer
 
@@ -412,12 +413,16 @@ struct FriendsTabView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: Theme.Spacing.md) {
                     ForEach(viewModel.recentlyAdded.prefix(10)) { sharedRecipe in
-                        NavigationLink(destination: RecipeDetailView(
-                            recipe: sharedRecipe.recipe,
-                            dependencies: dependencies,
-                            sharedBy: sharedRecipe.sharedBy,
-                            sharedAt: sharedRecipe.sharedAt
-                        )) {
+                        let transitionID = "friends-recent-\(sharedRecipe.recipe.id.uuidString)"
+                        NavigationLink {
+                            RecipeDetailView(
+                                recipe: sharedRecipe.recipe,
+                                dependencies: dependencies,
+                                sharedBy: sharedRecipe.sharedBy,
+                                sharedAt: sharedRecipe.sharedAt
+                            )
+                            .navigationTransition(.zoom(sourceID: transitionID, in: recipeTransition))
+                        } label: {
                             RecipeCardView(
                                 sharedRecipe: sharedRecipe,
                                 creatorTier: viewModel.sharerTiers[sharedRecipe.sharedBy.id],
@@ -425,6 +430,7 @@ struct FriendsTabView: View {
                             )
                         }
                         .buttonStyle(PressableScaleStyle())
+                        .matchedTransitionSource(id: transitionID, in: recipeTransition)
                     }
                 }
                 .padding(.horizontal, 16)
@@ -454,12 +460,16 @@ struct FriendsTabView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: Theme.Spacing.md) {
                     ForEach(recipes.prefix(10)) { sharedRecipe in
-                        NavigationLink(destination: RecipeDetailView(
-                            recipe: sharedRecipe.recipe,
-                            dependencies: dependencies,
-                            sharedBy: sharedRecipe.sharedBy,
-                            sharedAt: sharedRecipe.sharedAt
-                        )) {
+                        let transitionID = "friends-tag-\(tag)-\(sharedRecipe.recipe.id.uuidString)"
+                        NavigationLink {
+                            RecipeDetailView(
+                                recipe: sharedRecipe.recipe,
+                                dependencies: dependencies,
+                                sharedBy: sharedRecipe.sharedBy,
+                                sharedAt: sharedRecipe.sharedAt
+                            )
+                            .navigationTransition(.zoom(sourceID: transitionID, in: recipeTransition))
+                        } label: {
                             RecipeCardView(
                                 sharedRecipe: sharedRecipe,
                                 creatorTier: viewModel.sharerTiers[sharedRecipe.sharedBy.id],
@@ -467,6 +477,7 @@ struct FriendsTabView: View {
                             )
                         }
                         .buttonStyle(PressableScaleStyle())
+                        .matchedTransitionSource(id: transitionID, in: recipeTransition)
                     }
                 }
                 .padding(.horizontal, 16)
@@ -496,12 +507,16 @@ struct FriendsTabView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: Theme.Spacing.md) {
                     ForEach(viewModel.sharedRecipes.prefix(10)) { sharedRecipe in
-                        NavigationLink(destination: RecipeDetailView(
-                            recipe: sharedRecipe.recipe,
-                            dependencies: dependencies,
-                            sharedBy: sharedRecipe.sharedBy,
-                            sharedAt: sharedRecipe.sharedAt
-                        )) {
+                        let transitionID = "friends-all-\(sharedRecipe.recipe.id.uuidString)"
+                        NavigationLink {
+                            RecipeDetailView(
+                                recipe: sharedRecipe.recipe,
+                                dependencies: dependencies,
+                                sharedBy: sharedRecipe.sharedBy,
+                                sharedAt: sharedRecipe.sharedAt
+                            )
+                            .navigationTransition(.zoom(sourceID: transitionID, in: recipeTransition))
+                        } label: {
                             RecipeCardView(
                                 sharedRecipe: sharedRecipe,
                                 creatorTier: viewModel.sharerTiers[sharedRecipe.sharedBy.id],
@@ -509,6 +524,7 @@ struct FriendsTabView: View {
                             )
                         }
                         .buttonStyle(PressableScaleStyle())
+                        .matchedTransitionSource(id: transitionID, in: recipeTransition)
                     }
                 }
                 .padding(.horizontal, 16)

--- a/Cauldron/Features/Sharing/FriendsTabView.swift
+++ b/Cauldron/Features/Sharing/FriendsTabView.swift
@@ -94,6 +94,7 @@ struct FriendsTabView: View {
         NavigationStack(path: $navigationPath) {
             combinedFeedSection
                 .navigationTitle("Friends")
+                .toolbarTitleDisplayMode(.inlineLarge)
                 .toolbar { friendsToolbar }
                 .refreshable {
                     await refreshFriendsContent()
@@ -137,6 +138,7 @@ struct FriendsTabView: View {
                 }
             }
             .navigationTitle("Friends")
+                .toolbarTitleDisplayMode(.inlineLarge)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     if let user = userSession.currentUser {
@@ -177,6 +179,7 @@ struct FriendsTabView: View {
                 .frame(maxWidth: 980, alignment: .top)
                 .frame(maxWidth: .infinity, alignment: .top)
                 .navigationTitle("Friends")
+                .toolbarTitleDisplayMode(.inlineLarge)
                 .toolbar { friendsToolbar }
                 .refreshable {
                     await refreshFriendsContent()
@@ -266,13 +269,15 @@ struct FriendsTabView: View {
         ScrollView {
             LazyVStack(spacing: Theme.Spacing.md) {
                 // Friends section
-                VStack(spacing: 0) {
-                    SectionHeader(title: "Friends", icon: "person.2.fill", color: .green)
+                GlassEffectContainer {
+                    VStack(spacing: 0) {
+                        SectionHeader(title: "Friends", icon: "person.2.fill", color: .green)
 
-                    ConnectionsInlineView(dependencies: dependencies)
-                        .padding(.bottom, 8)
+                        ConnectionsInlineView(dependencies: dependencies)
+                            .padding(.bottom, 8)
+                    }
+                    .glassCard(cornerRadius: 16)
                 }
-                .glassCard(cornerRadius: 16)
                 .padding(.horizontal, 16)
                 .padding(.top, 12)
 

--- a/Cauldron/Features/Sharing/FriendsTabView.swift
+++ b/Cauldron/Features/Sharing/FriendsTabView.swift
@@ -263,13 +263,9 @@ struct FriendsTabView: View {
             LazyVStack(spacing: Theme.Spacing.md) {
                 // Friends section
                 GlassEffectContainer(spacing: 2) {
-                    VStack(spacing: 0) {
-                        SectionHeader(title: "Friends", icon: "person.2.fill", color: .green)
-
-                        ConnectionsInlineView(dependencies: dependencies, onAddFriend: { showingPeopleSearch = true })
-                            .padding(.bottom, 8)
-                    }
-                    .glassCard(cornerRadius: 16)
+                    ConnectionsInlineView(dependencies: dependencies, onAddFriend: { showingPeopleSearch = true })
+                        .padding(.bottom, 4)
+                        .glassCard(cornerRadius: 16)
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 12)

--- a/Cauldron/Features/Sharing/FriendsTabView.swift
+++ b/Cauldron/Features/Sharing/FriendsTabView.swift
@@ -314,29 +314,18 @@ struct FriendsTabView: View {
         Button {
             showingInviteSheet = true
         } label: {
-            HStack(spacing: 14) {
-                ZStack {
-                    Circle()
-                        .stroke(
-                            Color.cauldronOrange.opacity(0.9),
-                            style: StrokeStyle(lineWidth: 2, dash: [6, 5])
-                        )
-                        .frame(width: 52, height: 52)
+            HStack(spacing: 12) {
+                Image(systemName: "person.badge.plus")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.cauldronOrange)
+                    .frame(width: 32, height: 32)
+                    .background(Color.cauldronOrange.opacity(0.12), in: Circle())
 
-                    Image(systemName: "person.badge.plus")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundColor(.cauldronOrange)
-                }
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Invite Friends")
-                        .font(.headline)
-                        .foregroundColor(.primary)
-
-                    Text("Share your link and unlock referral rewards together.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
+                Text("Invite friends & unlock rewards")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
 
                 Spacer()
 
@@ -344,7 +333,8 @@ struct FriendsTabView: View {
                     .font(.caption.weight(.semibold))
                     .foregroundColor(.secondary)
             }
-            .padding(14)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 LinearGradient(

--- a/Cauldron/Features/Sharing/FriendsTabView.swift
+++ b/Cauldron/Features/Sharing/FriendsTabView.swift
@@ -268,7 +268,7 @@ struct FriendsTabView: View {
         ScrollView {
             LazyVStack(spacing: Theme.Spacing.md) {
                 // Friends section
-                GlassEffectContainer {
+                GlassEffectContainer(spacing: 2) {
                     VStack(spacing: 0) {
                         SectionHeader(title: "Friends", icon: "person.2.fill", color: .green)
 

--- a/Cauldron/Features/Sharing/FriendsTabView.swift
+++ b/Cauldron/Features/Sharing/FriendsTabView.swift
@@ -499,6 +499,7 @@ struct FriendsTabView: View {
                             CollectionCardView(
                                 collection: collection,
                                 recipeImages: collectionImageCache[collection.id] ?? [],
+                                owner: viewModel.owner(for: collection),
                                 dependencies: dependencies
                             )
                         }

--- a/Cauldron/Features/Sharing/FriendsTabViewModel.swift
+++ b/Cauldron/Features/Sharing/FriendsTabViewModel.swift
@@ -28,6 +28,12 @@ final class FriendsTabViewModel {
     // Tier information for shared recipe creators
     var sharerTiers: [UUID: UserTier] = [:]
 
+    /// Look up the owner of a friend's shared collection from the friends who
+    /// have shared recipes (used to tag collection cards with their creator).
+    func owner(for collection: Collection) -> User? {
+        sharedRecipes.first(where: { $0.sharedBy.id == collection.userId })?.sharedBy
+    }
+
     @ObservationIgnored
     private(set) var dependencies: DependencyContainer?
     @ObservationIgnored

--- a/Cauldron/Features/Sharing/PeopleSearchSheet.swift
+++ b/Cauldron/Features/Sharing/PeopleSearchSheet.swift
@@ -411,12 +411,24 @@ final class PeopleSearchViewModel {
             userIds.insert(connection.toUserId)
         }
 
-        for userId in userIds {
-            if usersMap[userId] == nil {
-                if let user = try? await dependencies.userCloudService.fetchUser(byUserId: userId) {
-                    usersMap[userId] = user
-                }
+        // Resolve users local-first (works offline), then cloud.
+        for userId in userIds where usersMap[userId] == nil {
+            if let cached = try? await dependencies.sharingRepository.fetchUser(id: userId) {
+                usersMap[userId] = cached
+            } else if let user = try? await dependencies.userCloudService.fetchUser(byUserId: userId) {
+                usersMap[userId] = user
             }
+        }
+
+        // Final fallback: build a minimal user from the request's embedded
+        // sender info so a pending request always renders (badge ↔ row stay in
+        // sync even when cloud/local lookups miss).
+        for connection in receivedRequests where usersMap[connection.fromUserId] == nil {
+            usersMap[connection.fromUserId] = User(
+                id: connection.fromUserId,
+                username: connection.fromUsername ?? "",
+                displayName: connection.fromDisplayName ?? connection.fromUsername ?? "Friend"
+            )
         }
     }
 

--- a/Cauldron/Features/Sharing/PeopleSearchSheet.swift
+++ b/Cauldron/Features/Sharing/PeopleSearchSheet.swift
@@ -21,8 +21,11 @@ struct PeopleSearchSheet: View {
         NavigationStack {
             ScrollView {
                 LazyVStack(spacing: 16) {
-                    // Search results or suggestions
+                    // Search results or (requests + suggestions)
                     if viewModel.searchText.isEmpty {
+                        if !resolvableRequests.isEmpty {
+                            requestsSection
+                        }
                         suggestionsSection
                     } else {
                         searchResultsSection
@@ -50,6 +53,40 @@ struct PeopleSearchSheet: View {
                 Button("OK") { }
             } message: {
                 Text(viewModel.alertMessage)
+            }
+        }
+    }
+
+    // MARK: - Requests Section
+
+    /// Pending received requests whose sender we've already resolved to a User
+    /// (so we never render a section header with no rows).
+    private var resolvableRequests: [(connection: Connection, user: User)] {
+        viewModel.receivedRequests.compactMap { connection in
+            viewModel.usersMap[connection.fromUserId].map { (connection, $0) }
+        }
+    }
+
+    private var requestsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "person.crop.circle.badge.plus")
+                    .foregroundColor(.cauldronOrange)
+                Text("Friend Requests")
+                    .font(.headline)
+                Spacer()
+            }
+
+            ForEach(resolvableRequests, id: \.connection.id) { item in
+                PeopleSearchUserRow(
+                    user: item.user,
+                    dependencies: dependencies,
+                    connectionState: .pendingIncoming,
+                    onConnect: {},
+                    onAccept: { await viewModel.acceptRequest(from: item.user) },
+                    onReject: { await viewModel.rejectRequest(from: item.user) },
+                    onRetry: {}
+                )
             }
         }
     }


### PR DESCRIPTION
A focused, simulator-verified UI pass on top of the design-system merge (#70). Every change was driven and checked via the iOS Simulator (XcodeBuildMCP UI automation). Full test suite: **689 passed, 0 failed**.

## Liquid Glass (native, used correctly)
- `glassEffect` reserved for the floating chrome layer; content uses material/solid. Learned + enforced: glass on scrolling content must be wrapped in a `GlassEffectContainer` (with `spacing` < the gap) or it composites over the nav/tab bars and merges.
- Recipe-detail section cards = contained glass; Search category chips = tinted **interactive** glass; owner/tier/favorite tags over recipe + collection images = `.clear` glass.
- Buttons use native `.buttonStyle(.glassProminent)` (Cook, onboarding).

## Identity & navigation
- Serif (system New York) **navigation titles** matching the serif section headers (global `UINavigationBarAppearance`, default glass background kept; skipped under tests).
- `.toolbarTitleDisplayMode(.inlineLarge)` on the main tabs.

## Motion / delight
- Zoom transitions (`matchedTransitionSource` + `.navigationTransition(.zoom)`) opening recipes & collections from Cook, Search, Friends, and the collections list — **section-scoped ids** so the animation always starts from the tapped card.
- Luminance-adaptive overlay text (white/black) over images so `.clear` glass tags stay legible.

## Friends rework
- Compact single-card header: redundant title removed, See All inlined.
- Pending requests + add-friends unified into **one sheet** (`PeopleSearchSheet`), entered via a badge-able "Add" tile; requests resolve local→cloud→embedded-connection fallback so the badge and row stay in sync.
- Owner tags on friends' recipe and collection cards.

## Other polish
- Recipe header chips → `.ultraThinMaterial`; smaller tag text; Cook button sized via `controlSize(.extraLarge)`; profile avatar out of the toolbar overflow.

## Known follow-ups (non-blocking)
- Tune the luminance threshold (0.6) if a label flips wrong on a real device.
- Owner tags on the collections See-All list; `UnitConverter` concurrency cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)