### PR TITLE
Polish, delight & cleanup: Liquid Glass, serif voice, onboarding rework

### DIFF
--- a/Cauldron/Assets.xcassets/LaunchBackground.colorset/Contents.json
+++ b/Cauldron/Assets.xcassets/LaunchBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.918",
+          "green" : "0.945",
+          "red" : "0.965"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.051",
+          "green" : "0.071",
+          "red" : "0.094"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Cauldron/ContentView.swift
+++ b/Cauldron/ContentView.swift
@@ -69,8 +69,8 @@ struct ContentView: View {
                                 await userSession.initialize(dependencies: dependencies)
                             }
                         )
-                    } else if userSession.needsOnboarding {
-                        // Show onboarding for new users
+                    } else if userSession.needsOnboarding || RuntimeEnvironment.shouldForceOnboarding {
+                        // Show onboarding for new users (or when previewing via launch flag)
                         OnboardingView(dependencies: dependencies) {
                             // Onboarding completed, will trigger view update
                         }

--- a/Cauldron/Core/Components/TierRoadmapView.swift
+++ b/Cauldron/Core/Components/TierRoadmapView.swift
@@ -15,6 +15,7 @@ struct TierRoadmapView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var showingImporter = false
     @State private var showingEditor = false
+    @State private var animatedProgress: CGFloat = 0
 
     var body: some View {
         NavigationStack {
@@ -78,6 +79,8 @@ struct TierRoadmapView: View {
                     Image(systemName: currentTier.icon)
                         .font(.system(size: 28))
                         .foregroundColor(currentTier.color)
+                        .scaleEffect(animatedProgress > 0 || currentTier.nextTier == nil ? 1.0 : 0.7)
+                        .animation(.spring(response: 0.5, dampingFraction: 0.6).delay(0.1), value: animatedProgress)
                 }
 
                 // Tier info
@@ -108,7 +111,7 @@ struct TierRoadmapView: View {
                 let progress = Double(recipeCount - currentTier.requiredRecipes) / Double(nextTier.requiredRecipes - currentTier.requiredRecipes)
 
                 VStack(spacing: 8) {
-                    // Progress bar
+                    // Progress bar (animates from empty → current on appear)
                     GeometryReader { geo in
                         ZStack(alignment: .leading) {
                             RoundedRectangle(cornerRadius: 4)
@@ -117,10 +120,15 @@ struct TierRoadmapView: View {
 
                             RoundedRectangle(cornerRadius: 4)
                                 .fill(currentTier.color)
-                                .frame(width: geo.size.width * max(0.02, progress), height: 8)
+                                .frame(width: geo.size.width * max(0.02, animatedProgress), height: 8)
                         }
                     }
                     .frame(height: 8)
+                    .onAppear {
+                        withAnimation(.spring(response: 0.7, dampingFraction: 0.8).delay(0.15)) {
+                            animatedProgress = max(0.02, CGFloat(progress))
+                        }
+                    }
 
                     // Recipe count and next tier
                     HStack {
@@ -156,6 +164,7 @@ struct TierRoadmapView: View {
                     Image(systemName: "crown.fill")
                         .font(.caption)
                         .foregroundColor(.yellow)
+                        .symbolEffect(.pulse, options: .repeating)
                     Text("Max tier reached! Maximum search visibility boost active.")
                         .font(.caption)
                         .foregroundColor(.secondary)

--- a/Cauldron/Core/Components/TierRoadmapView.swift
+++ b/Cauldron/Core/Components/TierRoadmapView.swift
@@ -24,13 +24,6 @@ struct TierRoadmapView: View {
             ScrollView {
                 GlassEffectContainer(spacing: 2) {
                     VStack(spacing: 16) {
-                        // Explainer
-                        Text("The more recipes you save, the higher your tier and search visibility boost.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal)
-
                         // Combined current + next tier section
                         combinedProgressSection
 
@@ -142,14 +135,14 @@ struct TierRoadmapView: View {
 
                     // Recipe count and next tier
                     HStack {
-                        Text("\(recipeCount)/\(nextTier.requiredRecipes) recipes")
+                        Text("\(recipeCount)/\(nextTier.requiredRecipes)")
                             .font(.caption)
                             .foregroundColor(.secondary)
 
                         Spacer()
 
                         HStack(spacing: 4) {
-                            Text("Next:")
+                            Text("\(recipesNeeded) to")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                             Image(systemName: nextTier.icon)
@@ -161,12 +154,6 @@ struct TierRoadmapView: View {
                                 .foregroundColor(nextTier.color)
                         }
                     }
-
-                    // Recipes needed hint
-                    Text("\(recipesNeeded) more \(recipesNeeded == 1 ? "recipe" : "recipes") to unlock +\(Int((nextTier.searchBoost - currentTier.searchBoost) * 100))% boost")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
             } else {
                 // Max tier reached
@@ -199,10 +186,6 @@ struct TierRoadmapView: View {
                     .fontWeight(.medium)
                 Spacer()
             }
-
-            Text("Import from links, generate with AI, or create your own to level up faster")
-                .font(.caption)
-                .foregroundColor(.secondary)
 
             if isAIAvailable {
                 Button {

--- a/Cauldron/Core/Components/TierRoadmapView.swift
+++ b/Cauldron/Core/Components/TierRoadmapView.swift
@@ -15,31 +15,35 @@ struct TierRoadmapView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var showingImporter = false
     @State private var showingEditor = false
+    @State private var showingAIGenerator = false
+    @State private var isAIAvailable = false
     @State private var animatedProgress: CGFloat = 0
 
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack(spacing: 16) {
-                    // Explainer
-                    Text("The more recipes you save, the higher your tier and search visibility boost.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal)
+                GlassEffectContainer(spacing: 2) {
+                    VStack(spacing: 16) {
+                        // Explainer
+                        Text("The more recipes you save, the higher your tier and search visibility boost.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal)
 
-                    // Combined current + next tier section
-                    combinedProgressSection
+                        // Combined current + next tier section
+                        combinedProgressSection
 
-                    // Add recipe CTA
-                    addRecipeCTA
+                        // Add recipe CTA
+                        addRecipeCTA
 
-                    // All tiers overview
-                    allTiersSection
+                        // All tiers overview
+                        allTiersSection
+                    }
                 }
                 .padding()
             }
-            .background(Color.cauldronBackground.ignoresSafeArea())
+            .warmCanvas()
             .navigationTitle("Tier Progress")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -54,6 +58,12 @@ struct TierRoadmapView: View {
             }
             .sheet(isPresented: $showingEditor) {
                 RecipeEditorView(dependencies: dependencies)
+            }
+            .sheet(isPresented: $showingAIGenerator) {
+                AIRecipeGeneratorView(dependencies: dependencies)
+            }
+            .task {
+                isAIAvailable = await dependencies.foundationModelsService.isAvailable
             }
         }
     }
@@ -174,8 +184,7 @@ struct TierRoadmapView: View {
             }
         }
         .padding()
-        .background(Color.cauldronSecondaryBackground)
-        .cornerRadius(12)
+        .glassCard(cornerRadius: 12)
     }
 
     // MARK: - Add Recipe CTA
@@ -191,9 +200,21 @@ struct TierRoadmapView: View {
                 Spacer()
             }
 
-            Text("Import from links or create your own to level up faster")
+            Text("Import from links, generate with AI, or create your own to level up faster")
                 .font(.caption)
                 .foregroundColor(.secondary)
+
+            if isAIAvailable {
+                Button {
+                    showingAIGenerator = true
+                } label: {
+                    Label("Generate with AI", systemImage: "apple.intelligence")
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.cauldronOrange)
+            }
 
             HStack(spacing: 10) {
                 Button {
@@ -218,8 +239,7 @@ struct TierRoadmapView: View {
             }
         }
         .padding()
-        .background(Color.cauldronSecondaryBackground)
-        .cornerRadius(12)
+        .glassCard(cornerRadius: 12)
     }
 
     // MARK: - All Tiers Section
@@ -281,12 +301,14 @@ struct TierRoadmapView: View {
                 .font(.caption)
                 .foregroundColor(tier.searchBoost > 1.0 && isUnlocked ? .green : .secondary)
         }
-        .padding(.vertical, 6)
+        .padding(.vertical, 8)
         .padding(.horizontal, 10)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(isCurrentTier ? tier.color.opacity(0.1) : Color.clear)
-        )
+        .if(isCurrentTier) { row in
+            row.glassEffect(
+                .regular.tint(tier.color.opacity(0.35)),
+                in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+            )
+        }
     }
 }
 

--- a/Cauldron/Core/Parsing/QuantityTextParser.swift
+++ b/Cauldron/Core/Parsing/QuantityTextParser.swift
@@ -1,0 +1,74 @@
+//
+//  QuantityTextParser.swift
+//  Cauldron
+//
+//  Parses user-entered quantity text (decimals, fractions, mixed numbers, and
+//  ranges) into numeric values. Extracted from RecipeEditorViewModel so it can
+//  be reused and unit-tested independently of the editor UI.
+//
+
+import Foundation
+
+enum QuantityTextParser {
+    /// Parse quantity text into a value and optional upper bound (for ranges).
+    /// Examples: "2" → (2, nil); "1/2" → (0.5, nil); "1 1/2" → (1.5, nil);
+    /// "1-2" → (1, 2). Returns nil for empty or unparseable input.
+    static func parse(_ rawText: String) -> (value: Double, upperValue: Double?)? {
+        let trimmed = rawText.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+
+        // Range: "1-2" or "1 - 2"
+        if trimmed.contains("-") {
+            let components = trimmed.components(separatedBy: "-")
+            if components.count == 2,
+               let lower = parseSingleValue(components[0]),
+               let upper = parseSingleValue(components[1]) {
+                return (lower, upper)
+            }
+        }
+
+        // Single value
+        if let val = parseSingleValue(trimmed) {
+            return (val, nil)
+        }
+
+        return nil
+    }
+
+    private static func parseSingleValue(_ text: String) -> Double? {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty { return nil }
+
+        // Fractions like "1/2", "1/4", "2/3"
+        if trimmed.contains("/") {
+            let parts = trimmed.split(separator: "/")
+            if parts.count == 2,
+               let numerator = Double(parts[0].trimmingCharacters(in: .whitespaces)),
+               let denominator = Double(parts[1].trimmingCharacters(in: .whitespaces)),
+               denominator != 0 {
+                return numerator / denominator
+            }
+        }
+
+        // Mixed numbers like "1 1/2"
+        if trimmed.contains(" ") {
+            let parts = trimmed.split(separator: " ")
+            if parts.count == 2,
+               let whole = Double(parts[0].trimmingCharacters(in: .whitespaces)) {
+                let fractionPart = String(parts[1].trimmingCharacters(in: .whitespaces))
+                if fractionPart.contains("/") {
+                    let fracParts = fractionPart.split(separator: "/")
+                    if fracParts.count == 2,
+                       let numerator = Double(fracParts[0].trimmingCharacters(in: .whitespaces)),
+                       let denominator = Double(fracParts[1].trimmingCharacters(in: .whitespaces)),
+                       denominator != 0 {
+                        return whole + (numerator / denominator)
+                    }
+                }
+            }
+        }
+
+        // Regular decimals
+        return Double(trimmed)
+    }
+}

--- a/Cauldron/Core/Services/UnitConverter.swift
+++ b/Cauldron/Core/Services/UnitConverter.swift
@@ -36,7 +36,9 @@ enum UnitSystem: String, CaseIterable, Identifiable {
 }
 
 /// Pure helpers for converting quantities/ingredients between measurement systems.
-enum UnitConverter {
+/// `nonisolated` so it's safe to call from SwiftUI view bodies regardless of the
+/// project's default-actor isolation.
+nonisolated enum UnitConverter {
 
     // MARK: - Public API
 

--- a/Cauldron/Core/Utilities/RuntimeEnvironment.swift
+++ b/Cauldron/Core/Utilities/RuntimeEnvironment.swift
@@ -54,6 +54,17 @@ enum RuntimeEnvironment {
         #endif
     }
 
+    /// Treat the AI generator UI as available even where Apple Intelligence
+    /// isn't (e.g. the simulator), so the input layout can be reviewed.
+    /// Generation itself still requires real on-device support.
+    nonisolated static var forceAIGeneratorUI: Bool {
+        #if DEBUG
+        arguments.contains("--cauldron-ai-preview")
+        #else
+        false
+        #endif
+    }
+
     nonisolated static var canUseCloudKit: Bool {
         !isRunningTests && !isRunningCI && !isCloudKitForcedOff && !isSimulatorQAMode
     }

--- a/Cauldron/Core/Utilities/RuntimeEnvironment.swift
+++ b/Cauldron/Core/Utilities/RuntimeEnvironment.swift
@@ -45,6 +45,15 @@ enum RuntimeEnvironment {
         #endif
     }
 
+    /// Force the onboarding flow for visual review (it's normally skipped in QA seed mode).
+    nonisolated static var shouldForceOnboarding: Bool {
+        #if DEBUG
+        arguments.contains("--cauldron-show-onboarding")
+        #else
+        false
+        #endif
+    }
+
     nonisolated static var canUseCloudKit: Bool {
         !isRunningTests && !isRunningCI && !isCloudKitForcedOff && !isSimulatorQAMode
     }

--- a/Cauldron/Features/AIGenerator/AIGeneratorComponents.swift
+++ b/Cauldron/Features/AIGenerator/AIGeneratorComponents.swift
@@ -107,6 +107,187 @@ struct AnimatedMeshGradient: View {
     }
 }
 
+// MARK: - Streaming Recipe Preview
+
+/// Renders the partially-generated recipe (title, ingredients, steps) as it
+/// streams in. Pure function of the partial result — no generator state.
+struct AIRecipePreview: View {
+    let partial: GeneratedRecipe.PartiallyGenerated
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            if let title = partial.title {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(title)
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .multilineTextAlignment(.leading)
+                        .foregroundStyle(.primary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    HStack(spacing: 20) {
+                        if let minutes = partial.totalMinutes {
+                            HStack(spacing: 6) {
+                                Image(systemName: "clock")
+                                    .foregroundColor(.cauldronOrange)
+                                Text("\(minutes) min")
+                            }
+                        }
+
+                        if let yields = partial.yields, !yields.isEmpty {
+                            HStack(spacing: 6) {
+                                Image(systemName: "person.2")
+                                    .foregroundColor(.cauldronOrange)
+                                Text(yields)
+                            }
+                        }
+                    }
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+                .background(.ultraThinMaterial)
+                .cornerRadius(20)
+                .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+
+            if let ingredients = partial.ingredients, !ingredients.isEmpty {
+                VStack(alignment: .leading, spacing: 16) {
+                    Label("Ingredients", systemImage: "basket")
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.primary)
+
+                    VStack(alignment: .leading, spacing: 12) {
+                        ForEach(Array(ingredients.enumerated()), id: \.offset) { _, ingredient in
+                            HStack(alignment: .top, spacing: 12) {
+                                Image(systemName: "circle.fill")
+                                    .font(.system(size: 6))
+                                    .foregroundColor(.cauldronOrange)
+                                    .padding(.top, 8)
+
+                                Text(Self.formatIngredient(ingredient))
+                                    .font(.body)
+                                    .lineLimit(nil)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            .padding(.vertical, 4)
+                            .transition(.opacity.combined(with: .move(edge: .leading)))
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+                .background(.ultraThinMaterial)
+                .cornerRadius(20)
+                .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
+            }
+
+            if let steps = partial.steps, !steps.isEmpty {
+                VStack(alignment: .leading, spacing: 16) {
+                    Label("Instructions", systemImage: "list.number")
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.primary)
+
+                    VStack(alignment: .leading, spacing: 20) {
+                        ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+                            HStack(alignment: .top, spacing: 16) {
+                                Text("\(index + 1)")
+                                    .font(.headline)
+                                    .foregroundColor(.white)
+                                    .frame(width: 32, height: 32)
+                                    .background(
+                                        Circle()
+                                            .fill(
+                                                LinearGradient(
+                                                    colors: [.cauldronOrange, .orange],
+                                                    startPoint: .topLeading,
+                                                    endPoint: .bottomTrailing
+                                                )
+                                            )
+                                    )
+                                    .shadow(color: .orange.opacity(0.3), radius: 4, x: 0, y: 2)
+
+                                Text(step.text?.decodingHTMLEntities ?? "")
+                                    .font(.body)
+                                    .lineSpacing(4)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            .transition(.opacity.combined(with: .move(edge: .bottom)))
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+                .background(.ultraThinMaterial)
+                .cornerRadius(20)
+                .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
+            }
+        }
+    }
+
+    /// Format an ingredient for display (matching RecipeDetailView style).
+    static func formatIngredient(_ ingredient: GeneratedIngredient.PartiallyGenerated) -> String {
+        var parts: [String] = []
+
+        if let value = ingredient.quantityValue, let unit = ingredient.quantityUnit {
+            let formattedValue = value.truncatingRemainder(dividingBy: 1) == 0
+                ? String(format: "%.0f", value)
+                : String(format: "%.1f", value)
+            parts.append("\(formattedValue) \(unit)")
+        }
+
+        if let name = ingredient.name {
+            parts.append(name)
+        }
+
+        if let note = ingredient.note {
+            parts.append("(\(note))")
+        }
+
+        return parts.joined(separator: " ")
+    }
+}
+
+// MARK: - Error Card
+
+struct AIErrorCard: View {
+    let error: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.title3)
+                .foregroundColor(.red)
+                .symbolEffect(.pulse)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Generation Failed")
+                    .font(.headline)
+                    .foregroundColor(.red)
+
+                Text(error)
+                    .font(.subheadline)
+                    .foregroundColor(.red.opacity(0.8))
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(20)
+        .background(Color.red.opacity(0.08))
+        .background(.ultraThinMaterial)
+        .cornerRadius(16)
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color.red.opacity(0.2), lineWidth: 1)
+        )
+    }
+}
+
 // MARK: - Press Events
 
 extension View {

--- a/Cauldron/Features/AIGenerator/AIGeneratorComponents.swift
+++ b/Cauldron/Features/AIGenerator/AIGeneratorComponents.swift
@@ -1,0 +1,120 @@
+//
+//  AIGeneratorComponents.swift
+//  Cauldron
+//
+//  Reusable, self-contained pieces extracted from AIRecipeGeneratorView to keep
+//  that file focused on generation flow/state.
+//
+
+import SwiftUI
+
+// MARK: - Tag Section
+
+struct RecipeTagSection: View {
+    let title: String
+    let icon: String
+    let tags: [RecipeCategory]
+    let onTagTap: (RecipeCategory) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: icon)
+                .font(.caption)
+                .fontWeight(.bold)
+                .foregroundColor(.secondary)
+                .textCase(.uppercase)
+                .padding(.horizontal, 4)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(tags, id: \.self) { tag in
+                        Button {
+                            onTagTap(tag)
+                        } label: {
+                            TagView(tag.tagValue)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 4) // Space for shadow
+            }
+        }
+    }
+}
+
+// MARK: - Unavailable Card
+
+/// Shown when Apple Intelligence isn't available on the device.
+struct AIUnavailableCard: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 44))
+                .foregroundColor(.orange)
+
+            Text("Apple Intelligence Not Available")
+                .font(.headline)
+
+            Text("This device doesn't support Apple Intelligence, or it may be disabled in Settings.")
+                .font(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(24)
+        .cardStyle()
+    }
+}
+
+// MARK: - Animated Mesh Gradient
+
+/// Immersive, slowly-drifting warm gradient backdrop for the AI generator.
+struct AnimatedMeshGradient: View {
+    @State private var animate = false
+
+    var body: some View {
+        ZStack {
+            Color.cauldronBackground
+
+            GeometryReader { proxy in
+                ZStack {
+                    Circle()
+                        .fill(Color.orange.opacity(0.15))
+                        .frame(width: proxy.size.width * 0.8)
+                        .blur(radius: 60)
+                        .offset(x: animate ? -50 : 50, y: animate ? -50 : 50)
+
+                    Circle()
+                        .fill(Color.yellow.opacity(0.15))
+                        .frame(width: proxy.size.width * 0.7)
+                        .blur(radius: 60)
+                        .offset(x: animate ? 100 : -100, y: animate ? 100 : -50)
+
+                    Circle()
+                        .fill(Color.red.opacity(0.1))
+                        .frame(width: proxy.size.width * 0.6)
+                        .blur(radius: 50)
+                        .offset(x: animate ? -30 : 150, y: animate ? 150 : -30)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .onAppear {
+            withAnimation(.easeInOut(duration: 10).repeatForever(autoreverses: true)) {
+                animate.toggle()
+            }
+        }
+    }
+}
+
+// MARK: - Press Events
+
+extension View {
+    func pressEvents(onPress: @escaping (Bool) -> Void) -> some View {
+        self.simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in onPress(true) }
+                .onEnded { _ in onPress(false) }
+        )
+    }
+}

--- a/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
+++ b/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
@@ -14,6 +14,17 @@ struct AIRecipeGeneratorView: View {
     @State private var viewModel: AIRecipeGeneratorViewModel
     @FocusState private var isPromptFocused: Bool
     @State private var isAvailable: Bool = false
+    @State private var showCategories = false
+
+    /// Tap-to-fill starter ideas to avoid the blank-prompt problem.
+    private let starterPrompts = [
+        "Quick weeknight dinner",
+        "Use up leftover chicken",
+        "Cozy soup for a cold night",
+        "High-protein lunch",
+        "Easy 5-ingredient dessert",
+        "One-pot vegetarian meal"
+    ]
 
     private var isBusyOrDone: Bool {
         viewModel.isGenerating || viewModel.generatedRecipe != nil
@@ -40,7 +51,7 @@ struct AIRecipeGeneratorView: View {
                                     generationStatusStrip
                                 } else {
                                     promptCard
-                                    categoriesCard
+                                    categoriesSection
                                 }
 
                                 if let partial = viewModel.partialRecipe {
@@ -85,26 +96,6 @@ struct AIRecipeGeneratorView: View {
                         dismiss()
                     }
                 }
-
-                if viewModel.generatedRecipe != nil {
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button("Save", systemImage: "checkmark") {
-                            // Prevent race condition by setting isSaving immediately
-                            guard !viewModel.isSaving else { return }
-                            viewModel.isSaving = true
-
-                            Task {
-                                if await viewModel.saveRecipe() {
-                                    // Dismiss immediately - CloudKit sync happens in background
-                                    dismiss()
-                                } else {
-                                    viewModel.isSaving = false
-                                }
-                            }
-                        }
-                        .disabled(viewModel.isSaving)
-                    }
-                }
             }
             .task {
                 isAvailable = await viewModel.checkAvailability() || RuntimeEnvironment.forceAIGeneratorUI
@@ -116,25 +107,13 @@ struct AIRecipeGeneratorView: View {
 
     // MARK: - Idle input
 
-    /// The "describe a dish" prompt card (primary path).
+    /// The "describe a dish" prompt card (primary path), with tap-to-fill ideas.
     private var promptCard: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.md) {
-            HStack(spacing: Theme.Spacing.sm) {
-                aiIcon(size: 40)
-                VStack(alignment: .leading, spacing: 1) {
-                    Text("Generate with AI")
-                        .font(.system(.title3, design: .serif).weight(.semibold))
-                    Text("Describe a dish, or pick categories below.")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-            }
-
             ZStack(alignment: .topLeading) {
                 TextEditor(text: $viewModel.prompt)
                     .scrollContentBackground(.hidden)
-                    .frame(minHeight: 110)
+                    .frame(minHeight: 96)
                     .padding(Theme.Spacing.sm)
                     .background(Color.appSurface.opacity(0.5), in: RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
                     .focused($isPromptFocused)
@@ -147,21 +126,73 @@ struct AIRecipeGeneratorView: View {
                         .allowsHitTesting(false)
                 }
             }
+
+            // Starter ideas (only before the user has typed anything)
+            if viewModel.prompt.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: Theme.Spacing.xs) {
+                        ForEach(starterPrompts, id: \.self) { idea in
+                            Button {
+                                Haptics.light()
+                                viewModel.prompt = idea
+                            } label: {
+                                Text(idea)
+                                    .font(.subheadline)
+                                    .foregroundStyle(Color.cauldronOrange)
+                                    .padding(.horizontal, Theme.Spacing.sm)
+                                    .padding(.vertical, Theme.Spacing.xs)
+                                    .background(Color.cauldronOrange.opacity(0.12), in: Capsule())
+                            }
+                            .buttonStyle(PressableScaleStyle())
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
         }
         .padding(Theme.Spacing.lg)
         .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Theme.Radius.xLarge, style: .continuous))
     }
 
-    /// Category selection card (cuisine / diet / time / meal), with chosen tags
-    /// surfaced as removable chips at the top.
-    private var categoriesCard: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
-            selectedTagsSummary
+    /// Categories tucked behind a disclosure so the prompt stays the hero.
+    private var categoriesSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            Button {
+                withAnimation(Theme.Animation.snappy) { showCategories.toggle() }
+            } label: {
+                HStack(spacing: Theme.Spacing.sm) {
+                    Label("Refine with categories", systemImage: "slider.horizontal.3")
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    if !viewModel.allSelectedCategories.isEmpty {
+                        Text("\(viewModel.allSelectedCategories.count)")
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(.white)
+                            .frame(minWidth: 20, minHeight: 20)
+                            .background(Color.cauldronOrange, in: Circle())
+                    }
+                    Image(systemName: "chevron.down")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .rotationEffect(.degrees(showCategories ? 180 : 0))
+                }
+                .padding(.horizontal, Theme.Spacing.lg)
+            }
+            .buttonStyle(.plain)
 
-            CategorySelectionRow(title: "Cuisine", icon: "map", options: RecipeCategory.all(in: .cuisine), selected: $viewModel.selectedCuisines)
-            CategorySelectionRow(title: "Diet", icon: "leaf", options: RecipeCategory.all(in: .dietary), selected: $viewModel.selectedDiets)
-            CategorySelectionRow(title: "Time", icon: "clock", options: RecipeCategory.all(in: .other), selected: $viewModel.selectedTimes)
-            CategorySelectionRow(title: "Meal", icon: "fork.knife", options: RecipeCategory.all(in: .mealType), selected: $viewModel.selectedTypes)
+            // Chosen categories stay visible even when collapsed.
+            if !showCategories {
+                selectedTagsSummary
+            }
+
+            if showCategories {
+                selectedTagsSummary
+                CategorySelectionRow(title: "Cuisine", icon: "map", options: RecipeCategory.all(in: .cuisine), selected: $viewModel.selectedCuisines)
+                CategorySelectionRow(title: "Diet", icon: "leaf", options: RecipeCategory.all(in: .dietary), selected: $viewModel.selectedDiets)
+                CategorySelectionRow(title: "Time", icon: "clock", options: RecipeCategory.all(in: .other), selected: $viewModel.selectedTimes)
+                CategorySelectionRow(title: "Meal", icon: "fork.knife", options: RecipeCategory.all(in: .mealType), selected: $viewModel.selectedTypes)
+            }
         }
         .padding(.vertical, Theme.Spacing.lg)
         .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Theme.Radius.xLarge, style: .continuous))
@@ -255,12 +286,21 @@ struct AIRecipeGeneratorView: View {
         }
     }
 
+    /// Single primary action that morphs Generate → generating → Save.
     private var floatingActionButton: some View {
         Button {
             if viewModel.isGenerating {
-                // Do nothing when generating
+                // No-op while generating.
             } else if viewModel.generatedRecipe != nil {
-                viewModel.regenerate()
+                guard !viewModel.isSaving else { return }
+                viewModel.isSaving = true
+                Task {
+                    if await viewModel.saveRecipe() {
+                        dismiss()
+                    } else {
+                        viewModel.isSaving = false
+                    }
+                }
             } else {
                 viewModel.generateRecipe()
                 isPromptFocused = false
@@ -271,12 +311,16 @@ struct AIRecipeGeneratorView: View {
                     ProgressView()
                         .progressViewStyle(.circular)
                         .tint(.white)
-                    Text("Generating Magic...")
+                    Text("Cooking up your recipe…")
                         .font(.headline)
                 } else if viewModel.generatedRecipe != nil {
-                    Image(systemName: "arrow.clockwise")
-                        .font(.headline)
-                    Text("Regenerate")
+                    if viewModel.isSaving {
+                        ProgressView().tint(.white)
+                    } else {
+                        Image(systemName: "checkmark")
+                            .font(.headline)
+                    }
+                    Text("Save Recipe")
                         .font(.headline)
                 } else {
                     Image(systemName: "wand.and.stars")
@@ -291,6 +335,7 @@ struct AIRecipeGeneratorView: View {
         .buttonStyle(.glassProminent)
         .controlSize(.extraLarge)
         .tint(.cauldronOrange)
+        .disabled(viewModel.isGenerating || viewModel.isSaving)
         .padding(.bottom, Theme.Spacing.xl)
     }
 

--- a/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
+++ b/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
@@ -14,7 +14,10 @@ struct AIRecipeGeneratorView: View {
     @State private var viewModel: AIRecipeGeneratorViewModel
     @FocusState private var isPromptFocused: Bool
     @State private var isAvailable: Bool = false
-    @State private var isInputExpanded: Bool = true
+
+    private var isBusyOrDone: Bool {
+        viewModel.isGenerating || viewModel.generatedRecipe != nil
+    }
 
     init(dependencies: DependencyContainer) {
         _viewModel = State(initialValue: AIRecipeGeneratorViewModel(dependencies: dependencies))
@@ -33,8 +36,12 @@ struct AIRecipeGeneratorView: View {
                             if !isAvailable {
                                 AIUnavailableCard()
                             } else {
-                                // Combined section that expands/collapses
-                                expandableInputSection
+                                if isBusyOrDone {
+                                    generationStatusStrip
+                                } else {
+                                    promptCard
+                                    categoriesCard
+                                }
 
                                 if let partial = viewModel.partialRecipe {
                                     AIRecipePreview(partial: partial)
@@ -100,237 +107,151 @@ struct AIRecipeGeneratorView: View {
                 }
             }
             .task {
-                isAvailable = await viewModel.checkAvailability()
-            }
-            .onChange(of: viewModel.isGenerating) { oldValue, newValue in
-                // Auto-collapse input section when generation starts
-                if !oldValue && newValue {
-                    withAnimation(.spring(response: 0.6, dampingFraction: 0.7)) {
-                        isInputExpanded = false
-                    }
-                }
+                isAvailable = await viewModel.checkAvailability() || RuntimeEnvironment.forceAIGeneratorUI
             }
         }
     }
 
     // MARK: - Sections
 
-    private var expandableInputSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header - always visible
-            Button {
-                // Only allow expanding/collapsing when not generating
-                if !viewModel.isGenerating {
-                    withAnimation(.spring(response: 0.4, dampingFraction: 0.7)) {
-                        isInputExpanded.toggle()
-                    }
+    // MARK: - Idle input
+
+    /// The "describe a dish" prompt card (primary path).
+    private var promptCard: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            HStack(spacing: Theme.Spacing.sm) {
+                aiIcon(size: 40)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Generate with AI")
+                        .font(.system(.title3, design: .serif).weight(.semibold))
+                    Text("Describe a dish, or pick categories below.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
                 }
-            } label: {
-                HStack(spacing: 16) {
-                    // Apple Intelligence icon
-                    ZStack {
-                        Circle()
-                            .fill(
-                                LinearGradient(
-                                    colors: [
-                                        Color.cauldronOrange,
-                                        Color.cauldronOrange.opacity(0.7)
-                                    ],
-                                    startPoint: .topLeading,
-                                    endPoint: .bottomTrailing
-                                )
-                            )
-                            .frame(width: 44, height: 44)
-                            .shadow(color: Color.cauldronOrange.opacity(0.3), radius: 8, x: 0, y: 4)
-
-                        Image(systemName: "apple.intelligence")
-                            .font(.system(size: 20))
-                            .foregroundColor(.white)
-                            .symbolEffect(.pulse, isActive: viewModel.isGenerating)
-                    }
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        // Show status text based on state
-                        if viewModel.isGenerating {
-                            HStack(spacing: 8) {
-                                Text(viewModel.generationProgress.description)
-                                    .font(.headline)
-                                    .fontWeight(.semibold)
-                                    .foregroundStyle(
-                                        LinearGradient(
-                                            colors: [.primary, .secondary],
-                                            startPoint: .leading,
-                                            endPoint: .trailing
-                                        )
-                                    )
-                            }
-                        } else if viewModel.generatedRecipe != nil {
-                            HStack(spacing: 6) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .font(.subheadline)
-                                    .foregroundColor(.green)
-                                Text("Recipe Ready")
-                                    .font(.headline)
-                                    .fontWeight(.semibold)
-                            }
-                        } else {
-                            // Before generation starts - show ready state
-                            Text("Generate with AI")
-                                .font(.system(.title3, design: .serif).weight(.semibold))
-                        }
-
-                        // Show recipe summary only when collapsed
-                        if !isInputExpanded && (viewModel.isGenerating || viewModel.generatedRecipe != nil) {
-                            if !viewModel.prompt.isEmpty {
-                                Text(viewModel.prompt)
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                                    .lineLimit(1)
-                            } else if viewModel.hasSelectedCategories {
-                                Text(viewModel.selectedCategoriesSummary)
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                                    .lineLimit(1)
-                            } else {
-                                Text("Custom recipe")
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                            }
-                        } else if !viewModel.isGenerating && viewModel.generatedRecipe == nil {
-                             Text("Create your perfect dish")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                        }
-                    }
-
-                    Spacer()
-
-                    // Show chevron when not generating
-                    if !viewModel.isGenerating {
-                        Image(systemName: "chevron.down")
-                            .font(.system(size: 14, weight: .bold))
-                            .foregroundColor(.secondary)
-                            .rotationEffect(.degrees(isInputExpanded ? 180 : 0))
-                    }
-                }
-                .padding(20)
+                Spacer()
             }
-            .buttonStyle(.plain)
-            .disabled(viewModel.isGenerating)
 
-            // Input fields - shown when expanded
-            if isInputExpanded && !viewModel.isGenerating {
-                VStack(alignment: .leading, spacing: 24) {
-                    Divider()
-                        .padding(.horizontal, 20)
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $viewModel.prompt)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 110)
+                    .padding(Theme.Spacing.sm)
+                    .background(Color.appSurface.opacity(0.5), in: RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
+                    .focused($isPromptFocused)
 
-                    // Prompt/Notes field
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text(viewModel.hasSelectedCategories ? "Additional Notes (Optional)" : "What would you like to cook?")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                            .foregroundStyle(.secondary)
-                            .padding(.horizontal, 20)
-
-                        ZStack(alignment: .topLeading) {
-                            TextEditor(text: $viewModel.prompt)
-                                .scrollContentBackground(.hidden)
-                                .frame(minHeight: 120)
-                                .padding(12)
-                                .background(Color.cauldronBackground.opacity(0.3))
-                                .cornerRadius(12)
-                                .padding(.horizontal, 20)
-                                .focused($isPromptFocused)
-
-                            if viewModel.prompt.isEmpty {
-                                Text(viewModel.hasSelectedCategories ? "e.g., no peanuts, extra spicy, low sodium..." : "Describe your ideal dish...")
-                                    .foregroundColor(.secondary.opacity(0.5))
-                                    .padding(.horizontal, 36)
-                                    .padding(.vertical, 24)
-                                    .allowsHitTesting(false)
-                            }
-                        }
-                    }
-
-                    // Categories
-                    VStack(alignment: .leading, spacing: 16) {
-                        if viewModel.allSelectedCategories.isEmpty {
-                            Text("Or select categories")
-                                .font(.subheadline)
-                                .fontWeight(.medium)
-                                .foregroundStyle(.secondary)
-                                .padding(.horizontal, 20)
-                        }
-
-                        selectedTagsSummary
-
-                        // Cuisine
-                        CategorySelectionRow(
-                            title: "Cuisine",
-                            icon: "map",
-                            options: RecipeCategory.all(in: .cuisine),
-                            selected: $viewModel.selectedCuisines
-                        )
-
-                        // Dietary
-                        CategorySelectionRow(
-                            title: "Diet",
-                            icon: "leaf",
-                            options: RecipeCategory.all(in: .dietary),
-                            selected: $viewModel.selectedDiets
-                        )
-
-                        // Time
-                        CategorySelectionRow(
-                            title: "Time",
-                            icon: "clock",
-                            options: RecipeCategory.all(in: .other),
-                            selected: $viewModel.selectedTimes
-                        )
-
-                        // Meal Type
-                        CategorySelectionRow(
-                            title: "Meal",
-                            icon: "fork.knife",
-                            options: RecipeCategory.all(in: .mealType),
-                            selected: $viewModel.selectedTypes
-                        )
-                    }
+                if viewModel.prompt.isEmpty {
+                    Text(viewModel.hasSelectedCategories ? "e.g. no peanuts, extra spicy, low sodium…" : "What would you like to cook?")
+                        .foregroundColor(.secondary.opacity(0.6))
+                        .padding(.horizontal, Theme.Spacing.md)
+                        .padding(.vertical, Theme.Spacing.lg)
+                        .allowsHitTesting(false)
                 }
-                .padding(.bottom, 24)
-                .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
-        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .padding(Theme.Spacing.lg)
+        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Theme.Radius.xLarge, style: .continuous))
     }
 
+    /// Category selection card (cuisine / diet / time / meal), with chosen tags
+    /// surfaced as removable chips at the top.
+    private var categoriesCard: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+            selectedTagsSummary
+
+            CategorySelectionRow(title: "Cuisine", icon: "map", options: RecipeCategory.all(in: .cuisine), selected: $viewModel.selectedCuisines)
+            CategorySelectionRow(title: "Diet", icon: "leaf", options: RecipeCategory.all(in: .dietary), selected: $viewModel.selectedDiets)
+            CategorySelectionRow(title: "Time", icon: "clock", options: RecipeCategory.all(in: .other), selected: $viewModel.selectedTimes)
+            CategorySelectionRow(title: "Meal", icon: "fork.knife", options: RecipeCategory.all(in: .mealType), selected: $viewModel.selectedTypes)
+        }
+        .padding(.vertical, Theme.Spacing.lg)
+        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Theme.Radius.xLarge, style: .continuous))
+    }
+
+    @ViewBuilder
     private var selectedTagsSummary: some View {
-        Group {
-            if !viewModel.allSelectedCategories.isEmpty {
-                VStack(alignment: .leading, spacing: 12) {
-                    Label("Selected", systemImage: "checkmark.circle.fill")
-                        .font(.caption)
-                        .fontWeight(.bold)
-                        .foregroundColor(.cauldronOrange)
-                        .textCase(.uppercase)
-                        .padding(.horizontal, 20)
-                    
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 10) {
-                            ForEach(viewModel.allSelectedCategories.sorted(by: { $0.tagValue < $1.tagValue })) { tag in
-                                TagView(tag.tagValue, isSelected: true, onRemove: {
-                                    withAnimation {
-                                        viewModel.removeCategory(tag)
-                                    }
-                                })
-                            }
+        if !viewModel.allSelectedCategories.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Label("Selected", systemImage: "checkmark.circle.fill")
+                    .font(.caption.weight(.bold))
+                    .foregroundColor(.cauldronOrange)
+                    .textCase(.uppercase)
+                    .padding(.horizontal, Theme.Spacing.lg)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(viewModel.allSelectedCategories.sorted(by: { $0.tagValue < $1.tagValue })) { tag in
+                            TagView(tag.tagValue, isSelected: true, onRemove: {
+                                withAnimation { viewModel.removeCategory(tag) }
+                            })
                         }
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 4)
+                    }
+                    .padding(.horizontal, Theme.Spacing.lg)
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+    }
+
+    // MARK: - Generating / done
+
+    /// Slim status strip shown while generating or after a recipe is ready.
+    private var generationStatusStrip: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            aiIcon(size: 36)
+
+            VStack(alignment: .leading, spacing: 2) {
+                if viewModel.isGenerating {
+                    Text(viewModel.generationProgress.description)
+                        .font(.headline)
+                } else {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                        Text("Recipe ready")
+                            .font(.headline)
                     }
                 }
-                .padding(.bottom, 8)
+
+                Text(promptSummary)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
             }
+
+            Spacer()
+
+            if viewModel.generatedRecipe != nil && !viewModel.isGenerating {
+                Button {
+                    viewModel.regenerate()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.headline)
+                        .foregroundStyle(Color.cauldronOrange)
+                }
+                .accessibilityLabel("Regenerate")
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Theme.Radius.large, style: .continuous))
+    }
+
+    private var promptSummary: String {
+        if !viewModel.prompt.isEmpty { return viewModel.prompt }
+        if viewModel.hasSelectedCategories { return viewModel.selectedCategoriesSummary }
+        return "Custom recipe"
+    }
+
+    /// Apple Intelligence brand icon used across the AI generator.
+    private func aiIcon(size: CGFloat) -> some View {
+        ZStack {
+            Circle()
+                .fill(Color.cauldronWarmGradient)
+                .frame(width: size, height: size)
+                .shadow(color: Color.cauldronOrange.opacity(0.3), radius: 8, x: 0, y: 4)
+            Image(systemName: "apple.intelligence")
+                .font(.system(size: size * 0.45))
+                .foregroundColor(.white)
+                .symbolEffect(.pulse, isActive: viewModel.isGenerating)
         }
     }
 
@@ -339,13 +260,8 @@ struct AIRecipeGeneratorView: View {
             if viewModel.isGenerating {
                 // Do nothing when generating
             } else if viewModel.generatedRecipe != nil {
-                // Regenerate
-                withAnimation(.spring(response: 0.4)) {
-                    isInputExpanded = true
-                }
                 viewModel.regenerate()
             } else {
-                // Generate
                 viewModel.generateRecipe()
                 isPromptFocused = false
             }

--- a/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
+++ b/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
@@ -28,27 +28,28 @@ struct AIRecipeGeneratorView: View {
                     .ignoresSafeArea()
                 
                 ScrollView {
-                    VStack(spacing: Theme.Spacing.xl) {
-                        if !isAvailable {
-                            AIUnavailableCard()
-                        } else {
-                            // Combined section that expands/collapses
-                            expandableInputSection
-                                .shadow(color: Color.black.opacity(0.05), radius: 15, x: 0, y: 5)
+                    GlassEffectContainer(spacing: Theme.Spacing.md) {
+                        VStack(spacing: Theme.Spacing.xl) {
+                            if !isAvailable {
+                                AIUnavailableCard()
+                            } else {
+                                // Combined section that expands/collapses
+                                expandableInputSection
 
-                            if let partial = viewModel.partialRecipe {
-                                AIRecipePreview(partial: partial)
-                                    .transition(.move(edge: .bottom).combined(with: .opacity))
-                            }
+                                if let partial = viewModel.partialRecipe {
+                                    AIRecipePreview(partial: partial)
+                                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                                }
 
-                            if let error = viewModel.errorMessage {
-                                AIErrorCard(error: error)
-                                    .transition(.scale.combined(with: .opacity))
+                                if let error = viewModel.errorMessage {
+                                    AIErrorCard(error: error)
+                                        .transition(.scale.combined(with: .opacity))
+                                }
                             }
                         }
                     }
-                    .padding(.vertical, 28)
-                    .padding(.horizontal, 16)
+                    .padding(.vertical, Theme.Spacing.xl)
+                    .padding(.horizontal, Theme.Spacing.md)
                     .padding(.bottom, 100) // Space for floating button
                     .animation(.spring(response: 0.5, dampingFraction: 0.8), value: viewModel.partialRecipe == nil)
                 }
@@ -175,8 +176,7 @@ struct AIRecipeGeneratorView: View {
                         } else {
                             // Before generation starts - show ready state
                             Text("Generate with AI")
-                                .font(.headline)
-                                .fontWeight(.semibold)
+                                .font(.system(.title3, design: .serif).weight(.semibold))
                         }
 
                         // Show recipe summary only when collapsed
@@ -301,13 +301,7 @@ struct AIRecipeGeneratorView: View {
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
-        .background(.ultraThinMaterial)
-        .background(Color.cauldronSecondaryBackground.opacity(0.5))
-        .cornerRadius(24)
-        .overlay(
-            RoundedRectangle(cornerRadius: 24)
-                .stroke(Color.white.opacity(0.2), lineWidth: 1)
-        )
+        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
     }
 
     private var selectedTagsSummary: some View {
@@ -340,171 +334,6 @@ struct AIRecipeGeneratorView: View {
         }
     }
 
-    private var unifiedStatusSection: some View {
-        HStack(spacing: 12) {
-            // Apple Intelligence icon
-            ZStack {
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                Color(red: 0.18, green: 0.28, blue: 0.99),
-                                Color(red: 0.57, green: 0.14, blue: 1.0)
-                            ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-                    .frame(width: 36, height: 36)
-
-                Image(systemName: "apple.intelligence")
-                    .font(.system(size: 16))
-                    .foregroundColor(.white)
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                // Show status text based on state
-                if viewModel.isGenerating {
-                    HStack(spacing: 8) {
-                        ProgressView()
-                            .scaleEffect(0.8)
-                            .tint(.cauldronOrange)
-                        Text(viewModel.generationProgress.description)
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                    }
-                } else if viewModel.generatedRecipe != nil {
-                    HStack(spacing: 8) {
-                        Image(systemName: viewModel.generationProgress.systemImage)
-                            .font(.caption)
-                            .foregroundColor(.green)
-                        Text(viewModel.generationProgress.description)
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                    }
-                } else {
-                    // Before generation starts - show ready state
-                    Text("Generate with AI")
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                }
-
-                // Show recipe summary only when generating or complete
-                if viewModel.isGenerating || viewModel.generatedRecipe != nil {
-                    if !viewModel.prompt.isEmpty {
-                        Text(viewModel.prompt)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .lineLimit(1)
-                    } else if viewModel.hasSelectedCategories {
-                        Text(viewModel.selectedCategoriesSummary)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .lineLimit(1)
-                    } else {
-                        Text("Custom recipe")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-            }
-
-            Spacer()
-
-            // Show regenerate button when recipe is complete
-            if viewModel.generatedRecipe != nil && !viewModel.isGenerating {
-                Button {
-                    withAnimation(.spring(response: 0.3)) {
-                        isInputExpanded = true
-                    }
-                    viewModel.regenerate()
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                        .font(.caption)
-                        .foregroundColor(.cauldronOrange)
-                }
-                .buttonStyle(.plain)
-            }
-        }
-        .padding(16)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.cauldronSecondaryBackground)
-        .cornerRadius(12)
-    }
-
-    private var combinedInputSection: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            // Prompt/Notes field
-            VStack(alignment: .leading, spacing: 12) {
-                Text(viewModel.hasSelectedCategories ? "Additional Notes (Optional)" : "What would you like to cook?")
-                    .font(.headline)
-
-                ZStack(alignment: .topLeading) {
-                    TextEditor(text: $viewModel.prompt)
-                        .frame(minHeight: 100)
-                        .padding(14)
-                        .background(Color.cauldronBackground)
-                        .cornerRadius(12)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(isPromptFocused ? Color.cauldronOrange : Color.secondary.opacity(0.15), lineWidth: 1.5)
-                        )
-                        .focused($isPromptFocused)
-
-                    if viewModel.prompt.isEmpty {
-                        Text(viewModel.hasSelectedCategories ? "e.g., no peanuts, extra spicy, low sodium..." : "Describe your ideal dish...")
-                            .foregroundColor(.secondary.opacity(0.5))
-                            .padding(.horizontal, 18)
-                            .padding(.vertical, 22)
-                            .allowsHitTesting(false)
-                    }
-                }
-            }
-
-            Divider()
-                .padding(.vertical, 4)
-
-            // Categories
-            Text("Or select categories:")
-                .font(.subheadline)
-                .foregroundColor(.secondary)
-
-            // Cuisine
-            CategorySelectionRow(
-                title: "Cuisine",
-                icon: "map",
-                options: RecipeCategory.all(in: .cuisine),
-                selected: $viewModel.selectedCuisines
-            )
-
-            // Dietary
-            CategorySelectionRow(
-                title: "Diet",
-                icon: "leaf",
-                options: RecipeCategory.all(in: .dietary),
-                selected: $viewModel.selectedDiets
-            )
-
-            // Time
-            CategorySelectionRow(
-                title: "Time",
-                icon: "clock",
-                options: [.quickEasy, .onePot, .airFryer],
-                selected: $viewModel.selectedTimes
-            )
-
-            // Meal Type
-            CategorySelectionRow(
-                title: "Meal",
-                icon: "fork.knife",
-                options: RecipeCategory.all(in: .mealType),
-                selected: $viewModel.selectedTypes
-            )
-        }
-        .padding(20)
-        .cardStyle()
-    }
-
     private var floatingActionButton: some View {
         Button {
             if viewModel.isGenerating {
@@ -521,7 +350,7 @@ struct AIRecipeGeneratorView: View {
                 isPromptFocused = false
             }
         } label: {
-            HStack(spacing: 12) {
+            HStack(spacing: Theme.Spacing.sm) {
                 if viewModel.isGenerating {
                     ProgressView()
                         .progressViewStyle(.circular)
@@ -540,23 +369,13 @@ struct AIRecipeGeneratorView: View {
                         .font(.headline)
                 }
             }
-            .foregroundStyle(.white)
-            .padding(.horizontal, 24)
-            .padding(.vertical, 16)
-            .background(Color.orange, in: Capsule())
+            .padding(.horizontal, Theme.Spacing.xs)
+            .padding(.vertical, Theme.Spacing.xxs)
         }
-        .padding(.bottom, 32)
-    }
-
-    // Helper function to append tags to prompt
-    private func appendToPrompt(_ tag: String) {
-        if viewModel.prompt.isEmpty {
-            viewModel.prompt = tag
-        } else if !viewModel.prompt.contains(tag) {
-            // Add with proper spacing
-            let trimmed = viewModel.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-            viewModel.prompt = trimmed + (trimmed.hasSuffix(",") ? " " : ", ") + tag
-        }
+        .buttonStyle(.glassProminent)
+        .controlSize(.extraLarge)
+        .tint(.cauldronOrange)
+        .padding(.bottom, Theme.Spacing.xl)
     }
 
 }

--- a/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
+++ b/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
@@ -30,7 +30,7 @@ struct AIRecipeGeneratorView: View {
                 ScrollView {
                     VStack(spacing: Theme.Spacing.xl) {
                         if !isAvailable {
-                            unavailableSection
+                            AIUnavailableCard()
                         } else {
                             // Combined section that expands/collapses
                             expandableInputSection
@@ -432,24 +432,6 @@ struct AIRecipeGeneratorView: View {
         .cornerRadius(12)
     }
 
-    private var unavailableSection: some View {
-        VStack(spacing: 16) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.system(size: 44))
-                .foregroundColor(.orange)
-
-            Text("Apple Intelligence Not Available")
-                .font(.headline)
-
-            Text("This device doesn't support Apple Intelligence, or it may be disabled in Settings.")
-                .font(.body)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-        }
-        .padding(24)
-        .cardStyle()
-    }
-
     private var combinedInputSection: some View {
         VStack(alignment: .leading, spacing: 20) {
             // Prompt/Notes field
@@ -754,98 +736,6 @@ struct AIRecipeGeneratorView: View {
 }
 
 // MARK: - Recipe Tag Section
-
-struct RecipeTagSection: View {
-    let title: String
-    let icon: String
-    let tags: [RecipeCategory]
-    let onTagTap: (RecipeCategory) -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Label(title, systemImage: icon)
-                .font(.caption)
-                .fontWeight(.bold)
-                .foregroundColor(.secondary)
-                .textCase(.uppercase)
-                .padding(.horizontal, 4)
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 10) {
-                    ForEach(tags, id: \.self) { tag in
-                        Button {
-                            onTagTap(tag)
-                        } label: {
-                            TagView(tag.tagValue)
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-                .padding(.horizontal, 4)
-                .padding(.vertical, 4) // Space for shadow
-            }
-        }
-    }
-}
-
-
-
-// MARK: - Animated Mesh Gradient
-
-struct AnimatedMeshGradient: View {
-    @State private var animate = false
-    
-    var body: some View {
-        ZStack {
-            // Base background
-            Color.cauldronBackground
-            
-            // Moving orbs
-            GeometryReader { proxy in
-                ZStack {
-                    // Orb 1
-                    Circle()
-                        .fill(Color.orange.opacity(0.15))
-                        .frame(width: proxy.size.width * 0.8)
-                        .blur(radius: 60)
-                        .offset(x: animate ? -50 : 50, y: animate ? -50 : 50)
-                    
-                    // Orb 2
-                    Circle()
-                        .fill(Color.yellow.opacity(0.15))
-                        .frame(width: proxy.size.width * 0.7)
-                        .blur(radius: 60)
-                        .offset(x: animate ? 100 : -100, y: animate ? 100 : -50)
-                    
-                    // Orb 3
-                    Circle()
-                        .fill(Color.red.opacity(0.1))
-                        .frame(width: proxy.size.width * 0.6)
-                        .blur(radius: 50)
-                        .offset(x: animate ? -30 : 150, y: animate ? 150 : -30)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-        }
-        .onAppear {
-            withAnimation(.easeInOut(duration: 10).repeatForever(autoreverses: true)) {
-                animate.toggle()
-            }
-        }
-    }
-}
-
-// MARK: - View Modifiers
-
-extension View {
-    func pressEvents(onPress: @escaping (Bool) -> Void) -> some View {
-        self.simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in onPress(true) }
-                .onEnded { _ in onPress(false) }
-        )
-    }
-}
 
 #Preview {
     AIRecipeGeneratorView(dependencies: .preview())

--- a/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
+++ b/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 import FoundationModels
 
 /// View for generating recipes using Apple Intelligence
@@ -15,16 +16,29 @@ struct AIRecipeGeneratorView: View {
     @FocusState private var isPromptFocused: Bool
     @State private var isAvailable: Bool = false
     @State private var showCategories = false
+    @State private var placeholderIndex = 0
 
-    /// Tap-to-fill starter ideas to avoid the blank-prompt problem.
-    private let starterPrompts = [
-        "Quick weeknight dinner",
-        "Use up leftover chicken",
-        "Cozy soup for a cold night",
-        "High-protein lunch",
-        "Easy 5-ingredient dessert",
-        "One-pot vegetarian meal"
+    /// Evocative examples that gently cycle through the empty prompt field.
+    private let cravingExamples = [
+        "cozy ramen for a rainy night",
+        "a showstopper dinner-party dessert",
+        "a high-protein lunch in 20 minutes",
+        "something spicy and comforting",
+        "a bright, colorful summer salad",
+        "a cozy one-pot meal for tonight"
     ]
+
+    /// Open-ended seeds for the "Surprise me" one-tap.
+    private let surprisePrompts = [
+        "a surprising dinner using everyday pantry staples",
+        "an adventurous dish from a cuisine I rarely cook",
+        "a nostalgic comfort food, reinvented",
+        "an impressive dessert that's secretly easy",
+        "a vibrant, colorful plate full of veggies",
+        "a cozy weeknight dinner with a clever twist"
+    ]
+
+    private let placeholderTimer = Timer.publish(every: 3.5, on: .main, in: .common).autoconnect()
 
     private var isBusyOrDone: Bool {
         viewModel.isGenerating || viewModel.generatedRecipe != nil
@@ -87,7 +101,7 @@ struct AIRecipeGeneratorView: View {
             .animation(.spring(), value: viewModel.selectedTimes.count)
             .animation(.spring(), value: viewModel.selectedTypes.count)
             .animation(.spring(), value: viewModel.prompt)
-            .navigationTitle("Generate Recipe")
+            .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -107,9 +121,19 @@ struct AIRecipeGeneratorView: View {
 
     // MARK: - Idle input
 
-    /// The "describe a dish" prompt card (primary path), with tap-to-fill ideas.
+    /// The "describe a dish" prompt card (primary path) — warm hero, a gently
+    /// rotating placeholder for ambient inspiration, and a "Surprise me" shortcut.
     private var promptCard: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+        VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+            // Warm hero — doubles as the screen's title (nav title is intentionally blank).
+            HStack(spacing: Theme.Spacing.sm) {
+                aiIcon(size: 44)
+                Text("What are you craving?")
+                    .font(.system(.title2, design: .serif).weight(.bold))
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
             ZStack(alignment: .topLeading) {
                 TextEditor(text: $viewModel.prompt)
                     .scrollContentBackground(.hidden)
@@ -119,39 +143,51 @@ struct AIRecipeGeneratorView: View {
                     .focused($isPromptFocused)
 
                 if viewModel.prompt.isEmpty {
-                    Text(viewModel.hasSelectedCategories ? "e.g. no peanuts, extra spicy, low sodium…" : "What would you like to cook?")
-                        .foregroundColor(.secondary.opacity(0.6))
-                        .padding(.horizontal, Theme.Spacing.md)
-                        .padding(.vertical, Theme.Spacing.lg)
-                        .allowsHitTesting(false)
+                    Group {
+                        if viewModel.hasSelectedCategories {
+                            Text("Add anything else… e.g. no peanuts, extra spicy")
+                        } else {
+                            // Cycles through evocative examples so it never feels static.
+                            Text("Try “\(cravingExamples[placeholderIndex])”")
+                                .id(placeholderIndex)
+                                .transition(.asymmetric(
+                                    insertion: .move(edge: .bottom).combined(with: .opacity),
+                                    removal: .move(edge: .top).combined(with: .opacity)
+                                ))
+                        }
+                    }
+                    .font(.body)
+                    .foregroundColor(.secondary.opacity(0.6))
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.lg)
+                    .allowsHitTesting(false)
                 }
             }
 
-            // Starter ideas (only before the user has typed anything)
+            // One-tap magic: fill a creative prompt and start cooking immediately.
             if viewModel.prompt.isEmpty {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: Theme.Spacing.xs) {
-                        ForEach(starterPrompts, id: \.self) { idea in
-                            Button {
-                                Haptics.light()
-                                viewModel.prompt = idea
-                            } label: {
-                                Text(idea)
-                                    .font(.subheadline)
-                                    .foregroundStyle(Color.cauldronOrange)
-                                    .padding(.horizontal, Theme.Spacing.sm)
-                                    .padding(.vertical, Theme.Spacing.xs)
-                                    .background(Color.cauldronOrange.opacity(0.12), in: Capsule())
-                            }
-                            .buttonStyle(PressableScaleStyle())
-                        }
-                    }
-                    .padding(.vertical, 2)
+                Button {
+                    Haptics.light()
+                    let pick = surprisePrompts.randomElement() ?? cravingExamples[placeholderIndex]
+                    viewModel.prompt = pick
+                    isPromptFocused = false
+                    viewModel.generateRecipe()
+                } label: {
+                    Label("Surprise me", systemImage: "wand.and.stars")
+                        .font(.subheadline.weight(.semibold))
                 }
+                .buttonStyle(.glass)
+                .tint(.cauldronOrange)
             }
         }
         .padding(Theme.Spacing.lg)
         .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Theme.Radius.xLarge, style: .continuous))
+        .onReceive(placeholderTimer) { _ in
+            guard viewModel.prompt.isEmpty, !viewModel.hasSelectedCategories else { return }
+            withAnimation(.easeInOut(duration: 0.5)) {
+                placeholderIndex = (placeholderIndex + 1) % cravingExamples.count
+            }
+        }
     }
 
     /// Categories tucked behind a disclosure so the prompt stays the hero.

--- a/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
+++ b/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
@@ -28,7 +28,7 @@ struct AIRecipeGeneratorView: View {
                     .ignoresSafeArea()
                 
                 ScrollView {
-                    VStack(spacing: 24) {
+                    VStack(spacing: Theme.Spacing.xl) {
                         if !isAvailable {
                             unavailableSection
                         } else {

--- a/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
+++ b/Cauldron/Features/AIGenerator/AIRecipeGeneratorView.swift
@@ -37,12 +37,12 @@ struct AIRecipeGeneratorView: View {
                                 .shadow(color: Color.black.opacity(0.05), radius: 15, x: 0, y: 5)
 
                             if let partial = viewModel.partialRecipe {
-                                recipePreviewSection(partial: partial)
+                                AIRecipePreview(partial: partial)
                                     .transition(.move(edge: .bottom).combined(with: .opacity))
                             }
 
                             if let error = viewModel.errorMessage {
-                                errorSection(error: error)
+                                AIErrorCard(error: error)
                                     .transition(.scale.combined(with: .opacity))
                             }
                         }
@@ -548,155 +548,6 @@ struct AIRecipeGeneratorView: View {
         .padding(.bottom, 32)
     }
 
-    private func recipePreviewSection(partial: GeneratedRecipe.PartiallyGenerated) -> some View {
-        VStack(alignment: .leading, spacing: 24) {
-            // Title and Metadata Card
-            if let title = partial.title {
-                VStack(alignment: .leading, spacing: 16) {
-                    Text(title)
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
-                        .multilineTextAlignment(.leading)
-                        .foregroundStyle(.primary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-
-                    // Time & Servings metadata
-                    HStack(spacing: 20) {
-                        if let minutes = partial.totalMinutes {
-                            HStack(spacing: 6) {
-                                Image(systemName: "clock")
-                                    .foregroundColor(.cauldronOrange)
-                                Text("\(minutes) min")
-                            }
-                        }
-
-                        if let yields = partial.yields, !yields.isEmpty {
-                            HStack(spacing: 6) {
-                                Image(systemName: "person.2")
-                                    .foregroundColor(.cauldronOrange)
-                                Text(yields)
-                            }
-                        }
-                    }
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                    .foregroundColor(.secondary)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(16)
-                .background(.ultraThinMaterial)
-                .cornerRadius(20)
-                .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
-                .transition(.move(edge: .top).combined(with: .opacity))
-            }
-
-            // Ingredients Card
-            if let ingredients = partial.ingredients, !ingredients.isEmpty {
-                VStack(alignment: .leading, spacing: 16) {
-                    Label("Ingredients", systemImage: "basket")
-                        .font(.title3)
-                        .fontWeight(.bold)
-                        .foregroundStyle(.primary)
-
-                    VStack(alignment: .leading, spacing: 12) {
-                        ForEach(Array(ingredients.enumerated()), id: \.offset) { index, ingredient in
-                            HStack(alignment: .top, spacing: 12) {
-                                Image(systemName: "circle.fill")
-                                    .font(.system(size: 6))
-                                    .foregroundColor(.cauldronOrange)
-                                    .padding(.top, 8)
-
-                                Text(formatIngredient(ingredient))
-                                    .font(.body)
-                                    .lineLimit(nil)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
-                            .padding(.vertical, 4)
-                            .transition(.opacity.combined(with: .move(edge: .leading)))
-                        }
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(16)
-                .background(.ultraThinMaterial)
-                .cornerRadius(20)
-                .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
-            }
-
-            // Instructions Card
-            if let steps = partial.steps, !steps.isEmpty {
-                VStack(alignment: .leading, spacing: 16) {
-                    Label("Instructions", systemImage: "list.number")
-                        .font(.title3)
-                        .fontWeight(.bold)
-                        .foregroundStyle(.primary)
-
-                    VStack(alignment: .leading, spacing: 20) {
-                        ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
-                            HStack(alignment: .top, spacing: 16) {
-                                Text("\(index + 1)")
-                                    .font(.headline)
-                                    .foregroundColor(.white)
-                                    .frame(width: 32, height: 32)
-                                    .background(
-                                        Circle()
-                                            .fill(
-                                                LinearGradient(
-                                                    colors: [.cauldronOrange, .orange],
-                                                    startPoint: .topLeading,
-                                                    endPoint: .bottomTrailing
-                                                )
-                                            )
-                                    )
-                                    .shadow(color: .orange.opacity(0.3), radius: 4, x: 0, y: 2)
-
-                                Text(step.text?.decodingHTMLEntities ?? "")
-                                    .font(.body)
-                                    .lineSpacing(4)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
-                            .transition(.opacity.combined(with: .move(edge: .bottom)))
-                        }
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(16)
-                .background(.ultraThinMaterial)
-                .cornerRadius(20)
-                .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
-            }
-        }
-    }
-
-    private func errorSection(error: String) -> some View {
-        HStack(alignment: .top, spacing: 16) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.title3)
-                .foregroundColor(.red)
-                .symbolEffect(.pulse)
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Generation Failed")
-                    .font(.headline)
-                    .foregroundColor(.red)
-                
-                Text(error)
-                    .font(.subheadline)
-                    .foregroundColor(.red.opacity(0.8))
-            }
-
-            Spacer(minLength: 0)
-        }
-        .padding(20)
-        .background(Color.red.opacity(0.08))
-        .background(.ultraThinMaterial)
-        .cornerRadius(16)
-        .overlay(
-            RoundedRectangle(cornerRadius: 16)
-                .stroke(Color.red.opacity(0.2), lineWidth: 1)
-        )
-    }
-
     // Helper function to append tags to prompt
     private func appendToPrompt(_ tag: String) {
         if viewModel.prompt.isEmpty {
@@ -708,31 +559,6 @@ struct AIRecipeGeneratorView: View {
         }
     }
 
-    // Helper function to format ingredient for display (matching RecipeDetailView style)
-    private func formatIngredient(_ ingredient: GeneratedIngredient.PartiallyGenerated) -> String {
-        var parts: [String] = []
-
-        // Add quantity and unit if available
-        if let value = ingredient.quantityValue,
-           let unit = ingredient.quantityUnit {
-            let formattedValue = value.truncatingRemainder(dividingBy: 1) == 0
-                ? String(format: "%.0f", value)
-                : String(format: "%.1f", value)
-            parts.append("\(formattedValue) \(unit)")
-        }
-
-        // Add name
-        if let name = ingredient.name {
-            parts.append(name)
-        }
-
-        // Add note if available
-        if let note = ingredient.note {
-            parts.append("(\(note))")
-        }
-
-        return parts.joined(separator: " ")
-    }
 }
 
 // MARK: - Recipe Tag Section

--- a/Cauldron/Features/Collections/CollectionCoverView.swift
+++ b/Cauldron/Features/Collections/CollectionCoverView.swift
@@ -1,0 +1,256 @@
+//
+//  CollectionCoverView.swift
+//  Cauldron
+//
+//  The paged cover carousel for a collection (custom cover image + recipe
+//  pages). Extracted from CollectionDetailView; owns its own cover-image
+//  loading state and page selection.
+//
+
+import SwiftUI
+
+struct CollectionCoverView: View {
+    let collection: Collection
+    let recipes: [Recipe]
+    let recipeImageSources: [CollectionRecipeImageSource]
+    let dependencies: DependencyContainer
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @State private var customCoverImage: UIImage?
+    @State private var loadedCoverKey: String?
+    @State private var isLoadingCoverImage = false
+    @State private var selectedCoverPage = 0
+
+    var body: some View {
+        VStack(spacing: 10) {
+            TabView(selection: $selectedCoverPage) {
+                if showsCustomCollectionCoverPage {
+                    customCoverView
+                        .tag(0)
+                        .accessibilityLabel("\(collection.name) collection cover")
+                }
+
+                if collectionCoverRecipePages.isEmpty && !showsCustomCollectionCoverPage {
+                    fallbackCoverView
+                        .tag(0)
+                        .accessibilityLabel("\(collection.name) collection cover")
+                }
+
+                ForEach(Array(collectionCoverRecipePages.enumerated()), id: \.element.id) { index, recipe in
+                    collectionRecipeCoverPage(for: recipe)
+                        .tag(showsCustomCollectionCoverPage ? index + 1 : index)
+                    .accessibilityLabel(recipe.title)
+                }
+            }
+            .id(collectionCoverPagesID)
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .frame(maxWidth: .infinity)
+            .frame(height: horizontalSizeClass == .regular ? 360 : 260)
+            .clipShape(.rect(cornerRadius: 22, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+            }
+            .shadow(color: Color.black.opacity(0.07), radius: 14, y: 6)
+            .background {
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                    .fill(Color.appSurface)
+            }
+
+            if collectionCoverPageCount > 1 {
+                collectionCoverPageIndicator
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 8)
+        .onChange(of: collectionCoverPageCount) { _, pageCount in
+            selectedCoverPage = min(selectedCoverPage, max(0, pageCount - 1))
+        }
+        .task(id: customCoverTaskID) {
+            await loadCustomCoverImage()
+        }
+    }
+
+    // MARK: - Derived
+
+    private var collectionColor: Color {
+        Color(hex: collection.color ?? "#FF9933") ?? .cauldronOrange
+    }
+
+    private var collectionSymbolName: String {
+        collection.symbolName ?? "folder.fill"
+    }
+
+    private var customCoverTaskID: String {
+        let remoteKey = collection.coverImageURL?.absoluteString ?? collection.cloudCoverImageRecordName ?? "no-cover"
+        return "\(collection.id.uuidString)|\(collection.coverImageType.rawValue)|\(remoteKey)"
+    }
+
+    private var showsCustomCollectionCoverPage: Bool {
+        collection.coverImageType == .customImage
+    }
+
+    private var collectionCoverPageCount: Int {
+        let customCoverCount = showsCustomCollectionCoverPage ? 1 : 0
+        return max(1, customCoverCount + collectionCoverRecipePages.count)
+    }
+
+    private var collectionCoverPagesID: String {
+        let recipePageKeys = collectionCoverRecipePages.map { recipe in
+            [
+                recipe.id.uuidString,
+                recipe.imageURL?.absoluteString ?? "no-url",
+                recipe.cloudImageRecordName ?? "no-cloud-image"
+            ].joined(separator: ":")
+        }
+        let customCoverKey = showsCustomCollectionCoverPage ? customCoverTaskID : "no-custom-cover"
+        return ([customCoverKey] + recipePageKeys).joined(separator: "|")
+    }
+
+    private var collectionCoverRecipePages: [Recipe] {
+        let recipesById = RecipeDeduplication.byIdPreferringBest(recipes)
+        let imageSourceByRecipeId = recipeImageSources.reduce(into: [UUID: CollectionRecipeImageSource]()) { result, source in
+            if let recipeId = source.recipeId, result[recipeId] == nil {
+                result[recipeId] = source
+            }
+        }
+        var seenRecipeIds = Set<UUID>()
+        let orderedRecipes = collection.recipeIds.compactMap { recipeId -> Recipe? in
+            guard seenRecipeIds.insert(recipeId).inserted else {
+                return nil
+            }
+            return recipesById[recipeId]
+        }
+
+        let imageCapableRecipes = orderedRecipes.filter { recipe in
+            let imageSource = imageSourceByRecipeId[recipe.id]
+            return recipe.imageURL != nil || recipe.cloudImageRecordName != nil || imageSource?.canLoadImage == true
+        }
+
+        return Array(imageCapableRecipes.prefix(10))
+    }
+
+    // MARK: - Pages
+
+    @ViewBuilder
+    private func collectionRecipeCoverPage(for recipe: Recipe) -> some View {
+        ZStack(alignment: .bottomLeading) {
+            RecipeImageView(
+                imageURL: recipe.imageURL,
+                size: .collectionTile,
+                showPlaceholderText: false,
+                recipeImageService: dependencies.recipeImageService,
+                recipeId: recipe.id,
+                ownerId: recipe.ownerId
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .clipped()
+
+            LinearGradient(
+                colors: [.clear, .black.opacity(0.18), .black.opacity(0.72)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+
+            recipeCoverTitle(recipe.title)
+        }
+    }
+
+    private func recipeCoverTitle(_ title: String) -> some View {
+        Text(title.recipeDetailLineBreakFriendly())
+            .font(.headline.weight(.semibold))
+            .foregroundStyle(.white)
+            .multilineTextAlignment(.leading)
+            .lineLimit(3)
+            .minimumScaleFactor(0.88)
+            .allowsTightening(true)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 18)
+            .padding(.bottom, 18)
+            .shadow(color: .black.opacity(0.35), radius: 4, y: 1)
+            .accessibilityHidden(true)
+    }
+
+    private var collectionCoverPageIndicator: some View {
+        HStack(spacing: 6) {
+            ForEach(0..<collectionCoverPageCount, id: \.self) { index in
+                Capsule()
+                    .fill(index == selectedCoverPage ? collectionColor : Color.secondary.opacity(0.28))
+                    .frame(width: index == selectedCoverPage ? 18 : 6, height: 6)
+                    .animation(.snappy(duration: 0.2), value: selectedCoverPage)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityLabel("Cover page \(selectedCoverPage + 1) of \(collectionCoverPageCount)")
+    }
+
+    @ViewBuilder
+    private var customCoverView: some View {
+        if let customCoverImage {
+            Image(uiImage: customCoverImage)
+                .resizable()
+                .scaledToFill()
+        } else if isLoadingCoverImage {
+            fallbackCoverView
+                .overlay {
+                    ProgressView()
+                        .tint(.white)
+                }
+        } else {
+            fallbackCoverView
+        }
+    }
+
+    @ViewBuilder
+    private var fallbackCoverView: some View {
+        CollectionCoverArtwork(
+            imageSources: [],
+            additionalRecipeCount: 0,
+            collectionColor: collectionColor,
+            collectionSymbolName: collectionSymbolName,
+            dependencies: dependencies,
+            iconScale: 82
+        )
+    }
+
+    // MARK: - Loading
+
+    @MainActor
+    private func loadCustomCoverImage() async {
+        guard collection.coverImageType == .customImage else {
+            customCoverImage = nil
+            loadedCoverKey = nil
+            isLoadingCoverImage = false
+            return
+        }
+
+        if loadedCoverKey != customCoverTaskID {
+            customCoverImage = nil
+        }
+        isLoadingCoverImage = true
+        defer { isLoadingCoverImage = false }
+
+        let image = await dependencies.entityImageLoader.loadCollectionCoverImage(
+            for: collection,
+            dependencies: dependencies
+        )
+
+        guard !Task.isCancelled else { return }
+
+        if let image {
+            if let currentImage = customCoverImage {
+                if !ImageLoadingPipeline.areImagesEqual(image, currentImage) {
+                    customCoverImage = image
+                }
+            } else {
+                customCoverImage = image
+            }
+            loadedCoverKey = customCoverTaskID
+        } else {
+            customCoverImage = nil
+            loadedCoverKey = nil
+        }
+    }
+}

--- a/Cauldron/Features/Collections/CollectionDetailView.swift
+++ b/Cauldron/Features/Collections/CollectionDetailView.swift
@@ -28,10 +28,6 @@ struct CollectionDetailView: View {
     @State private var collectionOwner: User?
     @State private var isSavingCollection = false
     @State private var savedCollection: Collection?
-    @State private var customCoverImage: UIImage?
-    @State private var loadedCoverKey: String?
-    @State private var isLoadingCoverImage = false
-    @State private var selectedCoverPage = 0
     @Environment(\.dismiss) private var dismiss
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @AppStorage(RecipeLayoutMode.appStorageKey) private var storedRecipeLayoutMode = RecipeLayoutMode.auto.rawValue
@@ -138,15 +134,6 @@ struct CollectionDetailView: View {
         !isLoading && collection.recipeCount > 0 && visibleRecipes.isEmpty
     }
 
-    private var collectionSymbolName: String {
-        collection.symbolName ?? "folder.fill"
-    }
-
-    private var customCoverTaskID: String {
-        let remoteKey = collection.coverImageURL?.absoluteString ?? collection.cloudCoverImageRecordName ?? "no-cover"
-        return "\(collection.id.uuidString)|\(collection.coverImageType.rawValue)|\(remoteKey)"
-    }
-
     private var recipeLayoutToolbarMenu: some View {
         RecipeLayoutToolbarButton(resolvedMode: resolvedRecipeLayoutMode) { mode in
             storedRecipeLayoutMode = mode.rawValue
@@ -156,7 +143,12 @@ struct CollectionDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                collectionCover
+                CollectionCoverView(
+                    collection: collection,
+                    recipes: recipes,
+                    recipeImageSources: recipeImageSources,
+                    dependencies: dependencies
+                )
 
                 VStack(alignment: .leading, spacing: 22) {
                     headerSection
@@ -178,9 +170,6 @@ struct CollectionDetailView: View {
         .searchable(text: $searchText, prompt: "Search recipes")
         .onChange(of: searchText) { _, _ in
             updateVisibleRecipes()
-        }
-        .onChange(of: collectionCoverPageCount) { _, pageCount in
-            selectedCoverPage = min(selectedCoverPage, max(0, pageCount - 1))
         }
         .sheet(item: $activeSheet) { sheet in
             sheetContent(for: sheet)
@@ -217,9 +206,6 @@ struct CollectionDetailView: View {
             await loadCollectionOwner()
             await loadRecipes()
             await loadExistingSavedCollection()
-        }
-        .task(id: customCoverTaskID) {
-            await loadCustomCoverImage()
         }
         .refreshable {
             await loadCollectionOwner(forceRefresh: true)
@@ -548,219 +534,7 @@ struct CollectionDetailView: View {
         }
     }
 
-    @MainActor
-    private func loadCustomCoverImage() async {
-        guard collection.coverImageType == .customImage else {
-            customCoverImage = nil
-            loadedCoverKey = nil
-            isLoadingCoverImage = false
-            return
-        }
-
-        if loadedCoverKey != customCoverTaskID {
-            customCoverImage = nil
-        }
-        isLoadingCoverImage = true
-        defer { isLoadingCoverImage = false }
-
-        let image = await dependencies.entityImageLoader.loadCollectionCoverImage(
-            for: collection,
-            dependencies: dependencies
-        )
-
-        guard !Task.isCancelled else { return }
-
-        if let image {
-            if let currentImage = customCoverImage {
-                if !ImageLoadingPipeline.areImagesEqual(image, currentImage) {
-                    customCoverImage = image
-                }
-            } else {
-                customCoverImage = image
-            }
-            loadedCoverKey = customCoverTaskID
-        } else {
-            customCoverImage = nil
-            loadedCoverKey = nil
-        }
-    }
-
     // MARK: - View Components
-
-    private var collectionCover: some View {
-        VStack(spacing: 10) {
-            TabView(selection: $selectedCoverPage) {
-                if showsCustomCollectionCoverPage {
-                    customCoverView
-                        .tag(0)
-                        .accessibilityLabel("\(collection.name) collection cover")
-                }
-
-                if collectionCoverRecipePages.isEmpty && !showsCustomCollectionCoverPage {
-                    fallbackCoverView
-                        .tag(0)
-                        .accessibilityLabel("\(collection.name) collection cover")
-                }
-
-                ForEach(Array(collectionCoverRecipePages.enumerated()), id: \.element.id) { index, recipe in
-                    collectionRecipeCoverPage(for: recipe)
-                        .tag(showsCustomCollectionCoverPage ? index + 1 : index)
-                    .accessibilityLabel(recipe.title)
-                }
-            }
-            .id(collectionCoverPagesID)
-            .tabViewStyle(.page(indexDisplayMode: .never))
-            .frame(maxWidth: .infinity)
-            .frame(height: horizontalSizeClass == .regular ? 360 : 260)
-            .clipShape(.rect(cornerRadius: 22, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 22, style: .continuous)
-                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-            }
-            .shadow(color: Color.black.opacity(0.07), radius: 14, y: 6)
-            .background {
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .fill(Color.appSurface)
-            }
-
-            if collectionCoverPageCount > 1 {
-                collectionCoverPageIndicator
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.top, 8)
-        .padding(.bottom, 8)
-    }
-
-    private var showsCustomCollectionCoverPage: Bool {
-        collection.coverImageType == .customImage
-    }
-
-    private var collectionCoverPageCount: Int {
-        let customCoverCount = showsCustomCollectionCoverPage ? 1 : 0
-        return max(1, customCoverCount + collectionCoverRecipePages.count)
-    }
-
-    private var collectionCoverPagesID: String {
-        let recipePageKeys = collectionCoverRecipePages.map { recipe in
-            [
-                recipe.id.uuidString,
-                recipe.imageURL?.absoluteString ?? "no-url",
-                recipe.cloudImageRecordName ?? "no-cloud-image"
-            ].joined(separator: ":")
-        }
-        let customCoverKey = showsCustomCollectionCoverPage ? customCoverTaskID : "no-custom-cover"
-        return ([customCoverKey] + recipePageKeys).joined(separator: "|")
-    }
-
-    private var collectionCoverRecipePages: [Recipe] {
-        let recipesById = RecipeDeduplication.byIdPreferringBest(recipes)
-        let imageSourceByRecipeId = recipeImageSources.reduce(into: [UUID: CollectionRecipeImageSource]()) { result, source in
-            if let recipeId = source.recipeId, result[recipeId] == nil {
-                result[recipeId] = source
-            }
-        }
-        var seenRecipeIds = Set<UUID>()
-        let orderedRecipes = collection.recipeIds.compactMap { recipeId -> Recipe? in
-            guard seenRecipeIds.insert(recipeId).inserted else {
-                return nil
-            }
-            return recipesById[recipeId]
-        }
-
-        let imageCapableRecipes = orderedRecipes.filter { recipe in
-            let imageSource = imageSourceByRecipeId[recipe.id]
-            return recipe.imageURL != nil || recipe.cloudImageRecordName != nil || imageSource?.canLoadImage == true
-        }
-
-        return Array(imageCapableRecipes.prefix(10))
-    }
-
-    @ViewBuilder
-    private func collectionRecipeCoverPage(for recipe: Recipe) -> some View {
-        ZStack(alignment: .bottomLeading) {
-            RecipeImageView(
-                imageURL: recipe.imageURL,
-                size: .collectionTile,
-                showPlaceholderText: false,
-                recipeImageService: dependencies.recipeImageService,
-                recipeId: recipe.id,
-                ownerId: recipe.ownerId
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .clipped()
-
-            LinearGradient(
-                colors: [.clear, .black.opacity(0.18), .black.opacity(0.72)],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-
-            recipeCoverTitle(recipe.title)
-        }
-    }
-
-    private func recipeCoverTitle(_ title: String) -> some View {
-        Text(title.recipeDetailLineBreakFriendly())
-            .font(.headline.weight(.semibold))
-            .foregroundStyle(.white)
-            .multilineTextAlignment(.leading)
-            .lineLimit(3)
-            .minimumScaleFactor(0.88)
-            .allowsTightening(true)
-            .fixedSize(horizontal: false, vertical: true)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 18)
-            .padding(.bottom, 18)
-            .shadow(color: .black.opacity(0.35), radius: 4, y: 1)
-            .accessibilityHidden(true)
-    }
-
-    private var collectionCoverPageIndicator: some View {
-        HStack(spacing: 6) {
-            ForEach(0..<collectionCoverPageCount, id: \.self) { index in
-                Capsule()
-                    .fill(index == selectedCoverPage ? collectionColor : Color.secondary.opacity(0.28))
-                    .frame(width: index == selectedCoverPage ? 18 : 6, height: 6)
-                    .animation(.snappy(duration: 0.2), value: selectedCoverPage)
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .accessibilityLabel("Cover page \(selectedCoverPage + 1) of \(collectionCoverPageCount)")
-    }
-
-    @ViewBuilder
-    private var customCoverView: some View {
-        if let customCoverImage {
-            Image(uiImage: customCoverImage)
-                .resizable()
-                .scaledToFill()
-        } else if isLoadingCoverImage {
-            fallbackCoverView
-                .overlay {
-                    ProgressView()
-                        .tint(.white)
-                }
-        } else {
-            fallbackCoverView
-        }
-    }
-
-    @ViewBuilder
-    private var fallbackCoverView: some View {
-        CollectionCoverArtwork(
-            imageSources: [],
-            additionalRecipeCount: 0,
-            collectionColor: collectionColor,
-            collectionSymbolName: collectionSymbolName,
-            dependencies: dependencies,
-            iconScale: 82
-        )
-    }
-
-    private var collectionColor: Color {
-        Color(hex: collection.color ?? "#FF9933") ?? .cauldronOrange
-    }
 
     private var emptyStateIconName: String {
         if shouldShowUnavailableRecipesEmptyState {

--- a/Cauldron/Features/Collections/CollectionDetailView.swift
+++ b/Cauldron/Features/Collections/CollectionDetailView.swift
@@ -618,9 +618,11 @@ struct CollectionDetailView: View {
             }
 
             if isOwned {
-                HStack(spacing: 10) {
-                    editCollectionButton
-                    addRecipesButton
+                GlassEffectContainer(spacing: 12) {
+                    HStack(spacing: 12) {
+                        editCollectionButton
+                        addRecipesButton
+                    }
                 }
                 .padding(.top, 2)
             }

--- a/Cauldron/Features/Collections/CollectionDetailView.swift
+++ b/Cauldron/Features/Collections/CollectionDetailView.swift
@@ -798,45 +798,28 @@ struct CollectionDetailView: View {
     }
 
     private var editCollectionButton: some View {
-        Button(action: {
+        Button {
             activeSheet = .edit
-        }) {
-            HStack(spacing: 6) {
-                Image(systemName: "pencil")
-                    .font(.subheadline)
-                Text("Edit Collection")
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-            }
-            .foregroundColor(.secondary)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity)
-            .background(Color.appSurface, in: Capsule())
-            .contentShape(Rectangle())
+        } label: {
+            Label("Edit Collection", systemImage: "pencil")
+                .font(.subheadline.weight(.medium))
+                .frame(maxWidth: .infinity)
         }
-        .buttonStyle(PressableScaleStyle())
+        .buttonStyle(.glass)
+        .controlSize(.large)
     }
 
     private var addRecipesButton: some View {
-        Button(action: {
+        Button {
             activeSheet = .addRecipes
-        }) {
-            HStack(spacing: 6) {
-                Image(systemName: "plus.circle.fill")
-                    .font(.subheadline)
-                Text("Add Recipes")
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-            }
-            .foregroundColor(.cauldronOrange)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity)
-            .background(Color.cauldronOrange.opacity(0.1), in: Capsule())
-            .contentShape(Rectangle())
+        } label: {
+            Label("Add Recipes", systemImage: "plus.circle.fill")
+                .font(.subheadline.weight(.medium))
+                .frame(maxWidth: .infinity)
         }
-        .buttonStyle(PressableScaleStyle())
+        .buttonStyle(.glassProminent)
+        .controlSize(.large)
+        .tint(.cauldronOrange)
     }
 
     // MARK: - Helpers

--- a/Cauldron/Features/Collections/CollectionFormView.swift
+++ b/Cauldron/Features/Collections/CollectionFormView.swift
@@ -144,7 +144,7 @@ struct CollectionFormView: View {
                                     RecipeImageView(thumbnailForRecipe: recipe, recipeImageService: dependencies.recipeImageService)
                                 } else {
                                     RoundedRectangle(cornerRadius: 8)
-                                        .fill(Color.gray.opacity(0.2))
+                                        .fill(Color.appSurface)
                                         .frame(width: 60, height: 60)
                                         .overlay(
                                             Image(systemName: "photo")

--- a/Cauldron/Features/CookMode/CookModeView.swift
+++ b/Cauldron/Features/CookMode/CookModeView.swift
@@ -22,7 +22,6 @@ struct CookModeView: View {
     @State private var checkedIngredientIDs: Set<UUID> = []
     @State private var scaleFactor: Double = 1.0
     @State private var unitSystem: UnitSystem = .original
-    @State private var showCompletionCelebration = false
 
     /// Ingredients adjusted for the current scale factor and unit system.
     /// Ingredient ids are preserved by both transforms, so check-off state
@@ -59,11 +58,6 @@ struct CookModeView: View {
                 regularWidthContent
             } else {
                 compactContent
-            }
-        }
-        .overlay {
-            if showCompletionCelebration {
-                cookCompleteCelebration
             }
         }
         .navigationTitle(recipe.title)
@@ -521,57 +515,23 @@ struct CookModeView: View {
     }
 
     /// Celebratory overlay shown when the cook finishes the last step.
-    private var cookCompleteCelebration: some View {
-        ZStack {
-            Color.black.opacity(0.35).ignoresSafeArea()
-
-            VStack(spacing: Theme.Spacing.md) {
-                Image(systemName: "checkmark.seal.fill")
-                    .font(.system(size: 72))
-                    .foregroundStyle(Color.cauldronOrange)
-                    .symbolEffect(.bounce)
-
-                Text("Nicely done!")
-                    .font(.system(.title, design: .serif).weight(.bold))
-
-                Text("You finished \(recipe.title).")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-            }
-            .padding(Theme.Spacing.xl)
-            .frame(maxWidth: 320)
-            .glassCard(cornerRadius: Theme.Radius.large)
-            .padding(Theme.Spacing.xl)
-            .transition(.scale.combined(with: .opacity))
-        }
-        .onAppear {
-            // Let the moment land, then close the session.
-            Task {
-                try? await Task.sleep(nanoseconds: 1_600_000_000)
-                coordinator.endSession()
-            }
-        }
-    }
-
     private var navigationControls: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: 12) {
             Button {
                 coordinator.previousStep()
             } label: {
                 Label("Back", systemImage: "chevron.left")
+                    .fontWeight(.semibold)
                     .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(coordinator.isFirstStep ? Color.cauldronSecondaryBackground.opacity(0.5) : Color.cauldronSecondaryBackground)
-                    .foregroundColor(coordinator.isFirstStep ? .secondary : .primary)
-                    .cornerRadius(12)
             }
+            .buttonStyle(.glass)
+            .controlSize(.extraLarge)
             .disabled(coordinator.isFirstStep)
 
             Button {
                 if coordinator.isLastStep {
                     Haptics.success()
-                    withAnimation(Theme.Animation.spring) { showCompletionCelebration = true }
+                    coordinator.endSession()
                 } else {
                     coordinator.nextStep()
                 }
@@ -582,15 +542,12 @@ struct CookModeView: View {
                     Image(systemName: coordinator.isLastStep ? "checkmark" : "chevron.right")
                 }
                 .frame(maxWidth: .infinity)
-                .padding()
-                .background(Color.cauldronOrange)
-                .foregroundColor(.white)
-                .cornerRadius(12)
-                .shadow(color: Color.cauldronOrange.opacity(0.3), radius: 4, x: 0, y: 2)
             }
+            .buttonStyle(.glassProminent)
+            .controlSize(.extraLarge)
+            .tint(.cauldronOrange)
         }
         .padding()
-        .background(Color.cauldronBackground)
     }
 }
 

--- a/Cauldron/Features/CookMode/CookModeView.swift
+++ b/Cauldron/Features/CookMode/CookModeView.swift
@@ -60,6 +60,7 @@ struct CookModeView: View {
                 compactContent
             }
         }
+        .background(Color.appBackground.ignoresSafeArea())
         .navigationTitle(recipe.title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/Cauldron/Features/CookMode/CookModeView.swift
+++ b/Cauldron/Features/CookMode/CookModeView.swift
@@ -22,6 +22,7 @@ struct CookModeView: View {
     @State private var checkedIngredientIDs: Set<UUID> = []
     @State private var scaleFactor: Double = 1.0
     @State private var unitSystem: UnitSystem = .original
+    @State private var showCompletionCelebration = false
 
     /// Ingredients adjusted for the current scale factor and unit system.
     /// Ingredient ids are preserved by both transforms, so check-off state
@@ -58,6 +59,11 @@ struct CookModeView: View {
                 regularWidthContent
             } else {
                 compactContent
+            }
+        }
+        .overlay {
+            if showCompletionCelebration {
+                cookCompleteCelebration
             }
         }
         .navigationTitle(recipe.title)
@@ -514,6 +520,40 @@ struct CookModeView: View {
         }
     }
 
+    /// Celebratory overlay shown when the cook finishes the last step.
+    private var cookCompleteCelebration: some View {
+        ZStack {
+            Color.black.opacity(0.35).ignoresSafeArea()
+
+            VStack(spacing: Theme.Spacing.md) {
+                Image(systemName: "checkmark.seal.fill")
+                    .font(.system(size: 72))
+                    .foregroundStyle(Color.cauldronOrange)
+                    .symbolEffect(.bounce)
+
+                Text("Nicely done!")
+                    .font(.system(.title, design: .serif).weight(.bold))
+
+                Text("You finished \(recipe.title).")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(Theme.Spacing.xl)
+            .frame(maxWidth: 320)
+            .glassCard(cornerRadius: Theme.Radius.large)
+            .padding(Theme.Spacing.xl)
+            .transition(.scale.combined(with: .opacity))
+        }
+        .onAppear {
+            // Let the moment land, then close the session.
+            Task {
+                try? await Task.sleep(nanoseconds: 1_600_000_000)
+                coordinator.endSession()
+            }
+        }
+    }
+
     private var navigationControls: some View {
         HStack(spacing: 16) {
             Button {
@@ -530,7 +570,8 @@ struct CookModeView: View {
 
             Button {
                 if coordinator.isLastStep {
-                    coordinator.endSession()
+                    Haptics.success()
+                    withAnimation(Theme.Animation.spring) { showCompletionCelebration = true }
                 } else {
                     coordinator.nextStep()
                 }

--- a/Cauldron/Features/CookMode/CookModeView.swift
+++ b/Cauldron/Features/CookMode/CookModeView.swift
@@ -517,36 +517,38 @@ struct CookModeView: View {
 
     /// Celebratory overlay shown when the cook finishes the last step.
     private var navigationControls: some View {
-        HStack(spacing: 12) {
-            Button {
-                coordinator.previousStep()
-            } label: {
-                Label("Back", systemImage: "chevron.left")
-                    .fontWeight(.semibold)
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.glass)
-            .controlSize(.extraLarge)
-            .disabled(coordinator.isFirstStep)
-
-            Button {
-                if coordinator.isLastStep {
-                    Haptics.success()
-                    coordinator.endSession()
-                } else {
-                    coordinator.nextStep()
-                }
-            } label: {
-                HStack {
-                    Text(coordinator.isLastStep ? "Done" : "Next")
+        GlassEffectContainer(spacing: 12) {
+            HStack(spacing: 12) {
+                Button {
+                    coordinator.previousStep()
+                } label: {
+                    Label("Back", systemImage: "chevron.left")
                         .fontWeight(.semibold)
-                    Image(systemName: coordinator.isLastStep ? "checkmark" : "chevron.right")
+                        .frame(maxWidth: .infinity)
                 }
-                .frame(maxWidth: .infinity)
+                .buttonStyle(.glass)
+                .controlSize(.extraLarge)
+                .disabled(coordinator.isFirstStep)
+
+                Button {
+                    if coordinator.isLastStep {
+                        Haptics.success()
+                        coordinator.endSession()
+                    } else {
+                        coordinator.nextStep()
+                    }
+                } label: {
+                    HStack {
+                        Text(coordinator.isLastStep ? "Done" : "Next")
+                            .fontWeight(.semibold)
+                        Image(systemName: coordinator.isLastStep ? "checkmark" : "chevron.right")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.glassProminent)
+                .controlSize(.extraLarge)
+                .tint(.cauldronOrange)
             }
-            .buttonStyle(.glassProminent)
-            .controlSize(.extraLarge)
-            .tint(.cauldronOrange)
         }
         .padding()
     }

--- a/Cauldron/Features/CookMode/ImprovedTimerRowView.swift
+++ b/Cauldron/Features/CookMode/ImprovedTimerRowView.swift
@@ -14,6 +14,7 @@ struct ImprovedTimerRowView: View {
 
     @State private var remainingSeconds: Int = 0
     @State private var updateTask: Task<Void, Never>?
+    @State private var didComplete = false
     /// Scales the large timer readout with Dynamic Type.
     @ScaledMetric(relativeTo: .largeTitle) private var timerFontSize: CGFloat = 32
     
@@ -73,9 +74,24 @@ struct ImprovedTimerRowView: View {
             }
         }
         .padding(16)
-        .background(Color.cauldronSecondaryBackground)
+        .background(didComplete ? Color.cauldronOrange.opacity(0.18) : Color.cauldronSecondaryBackground)
         .cornerRadius(16)
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color.cauldronOrange.opacity(didComplete ? 0.6 : 0), lineWidth: 2)
+        )
+        .scaleEffect(didComplete ? 1.03 : 1.0)
         .shadow(color: .black.opacity(0.05), radius: 8, x: 0, y: 4)
+        .animation(Theme.Animation.spring, value: didComplete)
+        .onChange(of: remainingSeconds) { _, newValue in
+            // Celebrate the moment a running timer hits zero.
+            if newValue <= 0 && !didComplete {
+                didComplete = true
+                Haptics.success()
+            } else if newValue > 0 && didComplete {
+                didComplete = false
+            }
+        }
         .onAppear {
             startUpdating()
         }

--- a/Cauldron/Features/Importer/ImporterView.swift
+++ b/Cauldron/Features/Importer/ImporterView.swift
@@ -250,7 +250,7 @@ struct ImporterView: View {
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled(true)
                         .padding(12)
-                        .background(Color.cauldronBackground)
+                        .background(Color.appSurface)
                         .cornerRadius(10)
                         .overlay(
                             RoundedRectangle(cornerRadius: 10)
@@ -305,7 +305,7 @@ struct ImporterView: View {
                 TextEditor(text: $viewModel.textInput)
                     .frame(minHeight: 220)
                     .padding(12)
-                    .background(Color.cauldronBackground)
+                    .background(Color.appSurface)
                     .cornerRadius(10)
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)

--- a/Cauldron/Features/Importer/RecipeImportPreviewView.swift
+++ b/Cauldron/Features/Importer/RecipeImportPreviewView.swift
@@ -233,6 +233,7 @@ struct RecipeImportPreviewView: View {
                     .padding(.vertical)
                 }
             }
+            .warmCanvas()
             .navigationTitle("Preview Recipe")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/Cauldron/Features/Importer/RecipeImportPreviewView.swift
+++ b/Cauldron/Features/Importer/RecipeImportPreviewView.swift
@@ -339,6 +339,8 @@ struct RecipeImportPreviewView: View {
             try await dependencies.recipeRepository.create(recipeToSave)
             AppLogger.parsing.info("Successfully saved imported recipe: \(recipeToSave.title)")
 
+            Haptics.success()
+
             // Call the callback to notify parent view
             onSave()
 

--- a/Cauldron/Features/Library/Components/RecipeHeaderSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeHeaderSection.swift
@@ -145,6 +145,8 @@ struct RecipeHeaderSection: View {
     private var primaryHeaderAction: some View {
         if recipe.isOwnedByCurrentUser() {
             Button {
+                // Haptic reflects the state we're moving to.
+                if localIsFavorite { Haptics.light() } else { Haptics.success() }
                 onToggleFavorite()
             } label: {
                 Image(systemName: localIsFavorite ? "star.fill" : "star")
@@ -152,6 +154,7 @@ struct RecipeHeaderSection: View {
                     .frame(width: 36, height: 36)
                     .foregroundStyle(localIsFavorite ? .yellow : .secondary)
                     .background(.ultraThinMaterial, in: Circle())
+                    .symbolEffect(.bounce, value: localIsFavorite)
             }
             .accessibilityLabel(localIsFavorite ? "Remove Favorite" : "Favorite")
         } else if hasOwnedCopy {

--- a/Cauldron/Features/Library/RecipeEditorView.swift
+++ b/Cauldron/Features/Library/RecipeEditorView.swift
@@ -57,6 +57,7 @@ struct RecipeEditorView: View {
 
                         Task {
                             if await viewModel.save() {
+                                Haptics.success()
                                 dismiss()
                                 // Call callback if provided (used during import flow)
                                 onSaveAndDismiss?()

--- a/Cauldron/Features/Library/RecipeEditorView.swift
+++ b/Cauldron/Features/Library/RecipeEditorView.swift
@@ -181,7 +181,7 @@ struct RecipeEditorView: View {
                     showingImageOptions = true
                 } label: {
                     RoundedRectangle(cornerRadius: 12)
-                        .fill(Color.gray.opacity(0.1))
+                        .fill(Color.appSurface)
                         .frame(height: 200)
                         .overlay {
                             VStack(spacing: 12) {
@@ -780,7 +780,7 @@ struct StepEditorRow: View {
             TextEditor(text: $step.text)
                 .frame(minHeight: 80)
                 .padding(8)
-                .background(Color(.systemGray6))
+                .background(Color.appSurface)
                 .cornerRadius(8)
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
@@ -868,7 +868,7 @@ struct TimerEditorRow: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(Color(.systemGray6))
+        .background(Color.appSurface)
         .cornerRadius(8)
         .onAppear {
             // Initialize display value based on seconds

--- a/Cauldron/Features/Library/RecipeEditorViewModel.swift
+++ b/Cauldron/Features/Library/RecipeEditorViewModel.swift
@@ -49,68 +49,6 @@ struct AdditionalQuantityInput: Identifiable {
     }
 }
 
-private enum QuantityTextParser {
-    static func parse(_ rawText: String) -> (value: Double, upperValue: Double?)? {
-        guard !rawText.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
-
-        let trimmed = rawText.trimmingCharacters(in: .whitespaces)
-
-        // Handle Range: "1-2" or "1 - 2"
-        if trimmed.contains("-") {
-            let components = trimmed.components(separatedBy: "-")
-            if components.count == 2,
-               let lower = parseSingleValue(components[0]),
-               let upper = parseSingleValue(components[1]) {
-                return (lower, upper)
-            }
-        }
-
-        // Handle Single Value
-        if let val = parseSingleValue(trimmed) {
-            return (val, nil)
-        }
-
-        return nil
-    }
-
-    private static func parseSingleValue(_ text: String) -> Double? {
-        let trimmed = text.trimmingCharacters(in: .whitespaces)
-        if trimmed.isEmpty { return nil }
-        
-        // Handle fractions like "1/2", "1/4", "2/3"
-        if trimmed.contains("/") {
-            let parts = trimmed.split(separator: "/")
-            if parts.count == 2,
-               let numerator = Double(parts[0].trimmingCharacters(in: .whitespaces)),
-               let denominator = Double(parts[1].trimmingCharacters(in: .whitespaces)),
-               denominator != 0 {
-                return numerator / denominator
-            }
-        }
-        
-        // Handle mixed numbers like "1 1/2" (1 and a half)
-        if trimmed.contains(" ") {
-            let parts = trimmed.split(separator: " ")
-            if parts.count == 2,
-               let whole = Double(parts[0].trimmingCharacters(in: .whitespaces)) {
-                let fractionPart = String(parts[1].trimmingCharacters(in: .whitespaces))
-                if fractionPart.contains("/") {
-                    let fracParts = fractionPart.split(separator: "/")
-                    if fracParts.count == 2,
-                       let numerator = Double(fracParts[0].trimmingCharacters(in: .whitespaces)),
-                       let denominator = Double(fracParts[1].trimmingCharacters(in: .whitespaces)),
-                       denominator != 0 {
-                        return whole + (numerator / denominator)
-                    }
-                }
-            }
-        }
-        
-        // Handle regular decimals
-        return Double(trimmed)
-    }
-}
-
 struct StepInput: Identifiable {
     let id = UUID()
     var text: String = ""

--- a/Cauldron/Features/Profile/DeleteAccountView.swift
+++ b/Cauldron/Features/Profile/DeleteAccountView.swift
@@ -29,8 +29,7 @@ struct DeleteAccountView: View {
 
                 // Title
                 Text("Delete Account")
-                    .font(.title)
-                    .fontWeight(.bold)
+                    .font(.system(.title, design: .serif).weight(.bold))
 
                 // Warning text
                 VStack(spacing: 16) {
@@ -52,8 +51,7 @@ struct DeleteAccountView: View {
                     .foregroundColor(.primary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding()
-                    .background(Color.secondary.opacity(0.1))
-                    .cornerRadius(12)
+                    .background(Color.appSurface, in: RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
                 }
                 .padding(.horizontal)
 
@@ -80,6 +78,7 @@ struct DeleteAccountView: View {
                 .padding(.horizontal)
                 .padding(.bottom, 32)
             }
+            .warmCanvas()
             .navigationTitle("Delete Account")
             .navigationBarTitleDisplayMode(.inline)
             .alert("Delete Account?", isPresented: $showingDeleteConfirmation) {

--- a/Cauldron/Features/Profile/EditProfileView.swift
+++ b/Cauldron/Features/Profile/EditProfileView.swift
@@ -106,7 +106,7 @@ struct ProfileEditView: View {
                                     .clipShape(Circle())
                             } else {
                                 Circle()
-                                    .fill(Color.gray.opacity(0.2))
+                                    .fill(Color.appSurface)
                                     .frame(width: 100, height: 100)
                                     .overlay(
                                         Image(systemName: "person.crop.circle")
@@ -134,8 +134,7 @@ struct ProfileEditView: View {
                         }
 
                         Text(displayName.isEmpty ? "Your Name" : displayName)
-                            .font(.title2)
-                            .fontWeight(.bold)
+                            .font(.system(.title2, design: .serif).weight(.bold))
 
                         Text("@\(username.isEmpty ? "username" : username)")
                             .font(.subheadline)
@@ -398,6 +397,7 @@ struct ProfileEditView: View {
                     .padding(.horizontal)
                 }
             }
+            .warmCanvas()
             .navigationTitle("Edit Profile")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/Cauldron/Features/Profile/EditProfileView.swift
+++ b/Cauldron/Features/Profile/EditProfileView.swift
@@ -86,8 +86,10 @@ struct ProfileEditView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 32) {
-                    // Profile Preview (matching onboarding)
+                    // Profile Preview with an inline edit menu on the avatar
                     VStack(spacing: 16) {
+                        ZStack(alignment: .bottomTrailing) {
+                        Group {
                         // Avatar Display
                         if selectedAvatarType == .photo {
                             if let profileImage = profileImage {
@@ -131,6 +133,51 @@ struct ProfileEditView: View {
                                         }
                                     }
                                 )
+                        }
+
+                        }
+
+                        // Inline avatar edit menu
+                        Menu {
+                            Button {
+                                selectedAvatarType = .emoji
+                                profileImage = nil
+                                showingAvatarPicker = true
+                            } label: {
+                                Label("Choose Emoji", systemImage: "face.smiling")
+                            }
+                            Button {
+                                selectedAvatarType = .photo
+                                imagePickerSourceType = .photoLibrary
+                                showingImagePicker = true
+                            } label: {
+                                Label("Photo Library", systemImage: "photo.on.rectangle")
+                            }
+                            Button {
+                                selectedAvatarType = .photo
+                                imagePickerSourceType = .camera
+                                showingImagePicker = true
+                            } label: {
+                                Label("Take Photo", systemImage: "camera")
+                            }
+                            if profileImage != nil || (selectedAvatarType == .photo && currentUser.profileImageURL != nil) {
+                                Divider()
+                                Button(role: .destructive) {
+                                    profileImage = nil
+                                    selectedAvatarType = .emoji
+                                } label: {
+                                    Label("Remove Photo", systemImage: "trash")
+                                }
+                            }
+                        } label: {
+                            Image(systemName: "pencil")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(.white)
+                                .frame(width: 32, height: 32)
+                                .background(Color.cauldronOrange, in: Circle())
+                                .overlay(Circle().strokeBorder(Color.appBackground, lineWidth: 2))
+                        }
+                        .accessibilityLabel("Edit avatar")
                         }
 
                         Text(displayName.isEmpty ? "Your Name" : displayName)
@@ -178,155 +225,6 @@ struct ProfileEditView: View {
                             Text("This is how others will see you")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
-                        }
-
-                        // Avatar selection - vertical stack for better readability
-                        VStack(alignment: .leading, spacing: 12) {
-                            Text("Profile Avatar")
-                                .font(.headline)
-                                .foregroundColor(.secondary)
-
-                            // Emoji Avatar Button
-                            Button {
-                                selectedAvatarType = .emoji
-                                profileImage = nil
-                                showingAvatarPicker = true
-                            } label: {
-                                HStack(spacing: 12) {
-                                    Image(systemName: "face.smiling")
-                                        .font(.title3)
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(profileEmoji != nil ? "Edit Emoji" : "Emoji Avatar")
-                                            .font(.subheadline)
-                                            .fontWeight(.medium)
-                                        Text("Choose an emoji and color")
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                    }
-                                    Spacer()
-                                    if selectedAvatarType == .emoji {
-                                        Image(systemName: "checkmark.circle.fill")
-                                            .foregroundColor(.cauldronOrange)
-                                    }
-                                }
-                                .padding()
-                                .background(selectedAvatarType == .emoji ? Color.cauldronOrange.opacity(0.15) : Color.cauldronSecondaryBackground)
-                                .foregroundColor(selectedAvatarType == .emoji ? .cauldronOrange : .primary)
-                                .cornerRadius(12)
-                            }
-                            .buttonStyle(.plain)
-
-                            // Photo Library Button
-                            Button {
-                                selectedAvatarType = .photo
-                                imagePickerSourceType = .photoLibrary
-                                showingImagePicker = true
-                            } label: {
-                                HStack(spacing: 12) {
-                                    Image(systemName: "photo.on.rectangle")
-                                        .font(.title3)
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text("Photo Library")
-                                            .font(.subheadline)
-                                            .fontWeight(.medium)
-                                        Text("Choose from your photos")
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                    }
-                                    Spacer()
-                                    if selectedAvatarType == .photo && (profileImage != nil || currentUser.profileImageURL != nil) {
-                                        Image(systemName: "checkmark.circle.fill")
-                                            .foregroundColor(.cauldronOrange)
-                                    }
-                                }
-                                .padding()
-                                .background(selectedAvatarType == .photo && (profileImage != nil || currentUser.profileImageURL != nil) ? Color.cauldronOrange.opacity(0.15) : Color.cauldronSecondaryBackground)
-                                .foregroundColor(selectedAvatarType == .photo && (profileImage != nil || currentUser.profileImageURL != nil) ? .cauldronOrange : .primary)
-                                .cornerRadius(12)
-                            }
-                            .buttonStyle(.plain)
-
-                            // Camera Button
-                            Button {
-                                selectedAvatarType = .photo
-                                imagePickerSourceType = .camera
-                                showingImagePicker = true
-                            } label: {
-                                HStack(spacing: 12) {
-                                    Image(systemName: "camera")
-                                        .font(.title3)
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text("Take Photo")
-                                            .font(.subheadline)
-                                            .fontWeight(.medium)
-                                        Text("Use your camera")
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                    }
-                                    Spacer()
-                                }
-                                .padding()
-                                .background(Color.cauldronSecondaryBackground)
-                                .foregroundColor(.primary)
-                                .cornerRadius(12)
-                            }
-                            .buttonStyle(.plain)
-
-                            // Show selected photo preview with remove option
-                            if let image = profileImage {
-                                HStack(spacing: 12) {
-                                    Image(uiImage: image)
-                                        .resizable()
-                                        .scaledToFill()
-                                        .frame(width: 44, height: 44)
-                                        .clipShape(Circle())
-
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text("Photo selected")
-                                            .font(.subheadline)
-                                            .fontWeight(.medium)
-                                        Text("Tap × to remove")
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                    }
-
-                                    Spacer()
-
-                                    Button {
-                                        profileImage = nil
-                                        selectedAvatarType = .emoji
-                                    } label: {
-                                        Image(systemName: "xmark.circle.fill")
-                                            .font(.title2)
-                                            .foregroundColor(.secondary)
-                                    }
-                                }
-                                .padding(12)
-                                .background(Color.cauldronOrange.opacity(0.1))
-                                .clipShape(RoundedRectangle(cornerRadius: 12))
-                            }
-
-                            // Show selected emoji preview
-                            if let emoji = profileEmoji, selectedAvatarType == .emoji {
-                                HStack(spacing: 12) {
-                                    Text(emoji)
-                                        .font(.system(size: 32))
-
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text("Emoji avatar selected")
-                                            .font(.subheadline)
-                                            .fontWeight(.medium)
-                                        Text("Tap Edit Emoji to change")
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                    }
-
-                                    Spacer()
-                                }
-                                .padding(12)
-                                .background(Color.cauldronOrange.opacity(0.1))
-                                .clipShape(RoundedRectangle(cornerRadius: 12))
-                            }
                         }
 
                         // App Icon Section

--- a/Cauldron/Features/Profile/UserProfileView.swift
+++ b/Cauldron/Features/Profile/UserProfileView.swift
@@ -49,27 +49,29 @@ struct UserProfileView: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: Theme.Spacing.lg) {
-                // Profile Header
-                profileHeader
+            GlassEffectContainer(spacing: 2) {
+                VStack(spacing: Theme.Spacing.lg) {
+                    // Profile Header
+                    profileHeader
 
-                // Rewards & Progress Section (only for current user)
-                if viewModel.isCurrentUser {
-                    rewardsSection
+                    // Rewards & Progress Section (only for current user)
+                    if viewModel.isCurrentUser {
+                        rewardsSection
+                    }
+
+                    // Connection Management Section
+                    if !viewModel.isCurrentUser {
+                        connectionSection
+                    }
+
+                    // Collections Section (only show if user has collections OR still loading the first time)
+                    if !viewModel.userCollections.isEmpty || (viewModel.isLoadingCollections && !hasLoadedInitialData) {
+                        collectionsSection
+                    }
+
+                    // Recipes Section
+                    recipesSection
                 }
-
-                // Connection Management Section
-                if !viewModel.isCurrentUser {
-                    connectionSection
-                }
-
-                // Collections Section (only show if user has collections OR still loading the first time)
-                if !viewModel.userCollections.isEmpty || (viewModel.isLoadingCollections && !hasLoadedInitialData) {
-                    collectionsSection
-                }
-
-                // Recipes Section
-                recipesSection
             }
             .padding()
         }
@@ -139,8 +141,7 @@ struct UserProfileView: View {
                 // Name row with edit button
                 HStack {
                     Text(displayUser.displayName)
-                        .font(.title3)
-                        .fontWeight(.bold)
+                        .font(.system(.title2, design: .serif).weight(.bold))
 
                     Spacer()
 
@@ -194,8 +195,7 @@ struct UserProfileView: View {
             }
         }
         .padding()
-        .background(Color.cauldronSecondaryBackground)
-        .cornerRadius(16)
+        .glassCard(cornerRadius: 16)
     }
 
     // MARK: - App Icons Section
@@ -238,8 +238,7 @@ struct UserProfileView: View {
             }
         }
         .padding()
-        .background(Color.cauldronSecondaryBackground)
-        .cornerRadius(16)
+        .glassCard(cornerRadius: 16)
     }
 
     private func iconCellWithProgress(theme: AppIconTheme) -> some View {
@@ -572,8 +571,7 @@ struct UserProfileView: View {
                 }
             }
             .padding()
-            .background(Color.cauldronSecondaryBackground)
-            .cornerRadius(16)
+            .glassCard(cornerRadius: 16)
         }
     }
 

--- a/Cauldron/Features/Settings/AvatarCustomizationSheet.swift
+++ b/Cauldron/Features/Settings/AvatarCustomizationSheet.swift
@@ -36,6 +36,7 @@ struct AvatarCustomizationSheet: View {
                 }
                 .padding()
             }
+            .warmCanvas()
             .navigationTitle("Customize Avatar")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/Cauldron/Features/Settings/OnboardingView.swift
+++ b/Cauldron/Features/Settings/OnboardingView.swift
@@ -7,39 +7,18 @@
 
 import SwiftUI
 
-/// First-run profile setup, presented as a short guided multi-step flow
-/// (welcome → identity → avatar → referral) with a progress indicator and a
-/// live avatar preview, rather than one long scrolling form.
+/// First-run setup: a short two-step flow — a welcoming intro, then a single
+/// "create profile" screen (avatar + name + optional referral) — instead of a
+/// long scrolling form.
 struct OnboardingView: View {
     let dependencies: DependencyContainer
     let onComplete: () -> Void
 
-    // MARK: - Step model
-
     private enum Step: Int, CaseIterable {
-        case welcome, identity, avatar, referral
-
-        var title: String {
-            switch self {
-            case .welcome: return "Welcome to Cauldron"
-            case .identity: return "Who are you?"
-            case .avatar: return "Make it yours"
-            case .referral: return "Almost there"
-            }
-        }
-
-        var subtitle: String {
-            switch self {
-            case .welcome: return "Your recipes, beautifully organized — and shared with friends."
-            case .identity: return "Pick a username and a name others will see."
-            case .avatar: return "Choose an emoji or photo for your profile."
-            case .referral: return "Got a code from a friend? Add it to connect instantly."
-            }
-        }
+        case welcome, profile
     }
 
     @State private var step: Step = .welcome
-    @Namespace private var stepGlass
 
     // MARK: - Profile state
 
@@ -56,57 +35,20 @@ struct OnboardingView: View {
     @State private var referralCode = ""
     @State private var didAutoApplyReferralCode = false
 
-    private var hasPhoto: Bool { profileImage != nil }
-    private var hasEmoji: Bool { profileEmoji != nil }
-
-    /// Whether the current step's requirements are satisfied (gates Continue).
-    private var canAdvance: Bool {
-        switch step {
-        case .welcome, .avatar, .referral:
-            return true
-        case .identity:
-            return isValid
-        }
-    }
-
     private var isValid: Bool {
         username.count >= 3 && username.count <= 20 &&
         displayName.count >= 1 &&
         username.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
     }
 
-    private var isLastStep: Bool { step == Step.allCases.last }
-
     // MARK: - Body
 
     var body: some View {
         VStack(spacing: 0) {
-            progressHeader
-
-            ScrollView {
-                VStack(alignment: .leading, spacing: Theme.Spacing.xl) {
-                    stepHeader
-
-                    switch step {
-                    case .welcome: welcomeStep
-                    case .identity: identityStep
-                    case .avatar: avatarStep
-                    case .referral: referralStep
-                    }
-
-                    if let error = errorMessage {
-                        Label(error, systemImage: "exclamationmark.triangle.fill")
-                            .font(.caption)
-                            .foregroundColor(.red)
-                            .padding(Theme.Spacing.sm)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(Color.red.opacity(0.1), in: RoundedRectangle(cornerRadius: Theme.Radius.small))
-                    }
-                }
-                .padding(Theme.Spacing.lg)
+            switch step {
+            case .welcome: welcomeStep
+            case .profile: profileStep
             }
-
-            footer
         }
         .background(Color.appBackground.ignoresSafeArea())
         .sheet(isPresented: $showingAvatarCustomization) {
@@ -124,165 +66,160 @@ struct OnboardingView: View {
         .onReceive(NotificationCenter.default.publisher(for: .openReferralInvite)) { notification in
             guard let code = notification.object as? String else { return }
             applyIncomingReferralCode(code)
-            // Jump to the referral step so the user sees it was applied.
-            withAnimation(Theme.Animation.spring) { step = .referral }
+            withAnimation(Theme.Animation.spring) { step = .profile }
         }
     }
 
-    // MARK: - Header / progress
-
-    private var progressHeader: some View {
-        HStack(spacing: Theme.Spacing.xs) {
-            ForEach(Step.allCases, id: \.rawValue) { s in
-                Capsule()
-                    .fill(s.rawValue <= step.rawValue ? Color.cauldronOrange : Color.appSeparator)
-                    .frame(height: 4)
-                    .animation(Theme.Animation.spring, value: step)
-            }
-        }
-        .padding(.horizontal, Theme.Spacing.lg)
-        .padding(.top, Theme.Spacing.md)
-    }
-
-    private var stepHeader: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
-            Text(step.title)
-                .font(.system(.largeTitle, design: .serif).weight(.bold))
-            Text(step.subtitle)
-                .font(.subheadline)
-                .foregroundColor(.secondary)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    // MARK: - Steps
+    // MARK: - Welcome
 
     private var welcomeStep: some View {
-        VStack(spacing: Theme.Spacing.lg) {
+        VStack(spacing: 0) {
+            Spacer()
+
+            // Hero mark
             Image("BrandMarks/CauldronIcon")
                 .resizable()
                 .scaledToFit()
-                .frame(width: 140, height: 140)
-                .shadow(color: .cauldronOrange.opacity(0.25), radius: 20, y: 8)
+                .frame(width: 132, height: 132)
+                .shadow(color: .cauldronOrange.opacity(0.25), radius: 24, y: 10)
 
-            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-                onboardingHighlight("square.and.arrow.down", "Import from the web, YouTube, TikTok & more")
-                onboardingHighlight("flame.fill", "Cook hands-free with step timers")
-                onboardingHighlight("person.2.fill", "Share recipes with friends")
+            VStack(spacing: Theme.Spacing.xs) {
+                Text("Cauldron")
+                    .font(.system(size: 40, design: .serif).weight(.bold))
+                Text("Your recipes, beautifully organized\nand shared with friends.")
+                    .font(.title3)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.top, Theme.Spacing.lg)
+
+            Spacer()
+
+            // Feature highlights
+            VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                highlight("square.and.arrow.down", "Import", "From the web, YouTube, TikTok & more")
+                highlight("flame.fill", "Cook", "Hands-free, step-by-step with timers")
+                highlight("person.2.fill", "Share", "Swap recipes with friends")
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .padding(.top, Theme.Spacing.md)
-    }
+            .padding(.horizontal, Theme.Spacing.xl)
 
-    private func onboardingHighlight(_ icon: String, _ text: String) -> some View {
-        HStack(spacing: Theme.Spacing.sm) {
-            Image(systemName: icon)
-                .font(.headline)
-                .foregroundStyle(Color.cauldronOrange)
-                .frame(width: 28)
-            Text(text)
-                .font(.subheadline)
             Spacer()
+            Spacer()
+
+            Button {
+                Haptics.light()
+                withAnimation(Theme.Animation.spring) { step = .profile }
+            } label: {
+                Text("Get Started")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.glassProminent)
+            .controlSize(.extraLarge)
+            .tint(.cauldronOrange)
+            .padding(.horizontal, Theme.Spacing.lg)
+            .padding(.bottom, Theme.Spacing.xl)
         }
     }
 
-    private var identityStep: some View {
-        VStack(spacing: Theme.Spacing.lg) {
-            avatarPreview
+    private func highlight(_ icon: String, _ title: String, _ subtitle: String) -> some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(Color.cauldronOrange)
+                .frame(width: 40, height: 40)
+                .background(Color.cauldronOrange.opacity(0.12), in: Circle())
 
-            fieldGroup(title: "Username", caption: "3–20 characters · letters, numbers, underscores") {
-                TextField("username", text: $username)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .textCase(.lowercase)
-            }
-
-            fieldGroup(title: "Display Name", caption: "This is how others will see you") {
-                TextField("Your Name", text: $displayName)
-                    .textInputAutocapitalization(.words)
-            }
-        }
-    }
-
-    private var avatarStep: some View {
-        VStack(spacing: Theme.Spacing.lg) {
-            avatarPreview
-
-            HStack(spacing: Theme.Spacing.sm) {
-                avatarOptionButton(icon: "face.smiling", label: hasEmoji ? "Edit Emoji" : "Emoji", selected: hasEmoji && !hasPhoto) {
-                    showingAvatarCustomization = true
-                }
-                avatarOptionButton(icon: "photo.on.rectangle", label: "Photos", selected: hasPhoto) {
-                    imagePickerSourceType = .photoLibrary
-                    showingImagePicker = true
-                }
-                avatarOptionButton(icon: "camera", label: "Camera", selected: false) {
-                    imagePickerSourceType = .camera
-                    showingImagePicker = true
-                }
-            }
-
-            if hasPhoto {
-                Button(role: .destructive) {
-                    withAnimation(Theme.Animation.snappy) { profileImage = nil }
-                } label: {
-                    Label("Remove photo", systemImage: "xmark.circle.fill")
-                        .font(.subheadline)
-                }
-                .frame(maxWidth: .infinity, alignment: .center)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.headline)
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
             }
         }
     }
 
-    private var referralStep: some View {
-        VStack(spacing: Theme.Spacing.lg) {
-            avatarPreview
+    // MARK: - Create Profile
 
-            fieldGroup(title: "Referral Code", caption: "Optional — unlocks an exclusive icon and connects you instantly.") {
-                TextField("Enter friend's code", text: $referralCode)
-                    .textInputAutocapitalization(.characters)
-                    .autocorrectionDisabled()
+    private var profileStep: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(spacing: Theme.Spacing.xl) {
+                    Text("Create your profile")
+                        .font(.system(.largeTitle, design: .serif).weight(.bold))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, Theme.Spacing.lg)
+
+                    avatarPreview
+
+                    fieldGroup(title: "Username", caption: "3–20 characters · letters, numbers, underscores") {
+                        TextField("username", text: $username)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .textCase(.lowercase)
+                    }
+
+                    fieldGroup(title: "Display Name", caption: "How others will see you") {
+                        TextField("Your Name", text: $displayName)
+                            .textInputAutocapitalization(.words)
+                    }
+
+                    fieldGroup(title: "Referral Code", caption: didAutoApplyReferralCode ? "Applied from your invite link." : "Optional — connect with a friend instantly.") {
+                        TextField("Enter code", text: $referralCode)
+                            .textInputAutocapitalization(.characters)
+                            .autocorrectionDisabled()
+                    }
+
+                    if let error = errorMessage {
+                        Label(error, systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                            .padding(Theme.Spacing.sm)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.red.opacity(0.1), in: RoundedRectangle(cornerRadius: Theme.Radius.small))
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.lg)
+                .padding(.bottom, Theme.Spacing.lg)
             }
 
-            if didAutoApplyReferralCode {
-                Label("Invite code applied from your link.", systemImage: "checkmark.seal.fill")
-                    .font(.caption)
-                    .foregroundColor(.green)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
+            footer
         }
     }
 
-    // MARK: - Shared step components
-
-    /// Live avatar + name preview shown across the profile-building steps.
     private var avatarPreview: some View {
         VStack(spacing: Theme.Spacing.sm) {
-            ZStack {
-                if let image = profileImage {
-                    Image(uiImage: image)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: 96, height: 96)
-                        .clipShape(Circle())
-                } else {
-                    Circle()
-                        .fill((profileColor.flatMap { Color(hex: $0) } ?? .cauldronOrange).opacity(0.15))
-                        .frame(width: 96, height: 96)
-                        .overlay {
-                            if let emoji = profileEmoji {
-                                Text(emoji).font(.system(size: 44))
-                            } else {
-                                Text(initials)
-                                    .font(.system(.title, design: .serif).weight(.semibold))
-                                    .foregroundColor(profileColor.flatMap { Color(hex: $0) } ?? .cauldronOrange)
+            ZStack(alignment: .bottomTrailing) {
+                Group {
+                    if let image = profileImage {
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 104, height: 104)
+                            .clipShape(Circle())
+                    } else {
+                        Circle()
+                            .fill((profileColor.flatMap { Color(hex: $0) } ?? .cauldronOrange).opacity(0.15))
+                            .frame(width: 104, height: 104)
+                            .overlay {
+                                if let emoji = profileEmoji {
+                                    Text(emoji).font(.system(size: 48))
+                                } else {
+                                    Text(initials)
+                                        .font(.system(.largeTitle, design: .serif).weight(.semibold))
+                                        .foregroundColor(profileColor.flatMap { Color(hex: $0) } ?? .cauldronOrange)
+                                }
                             }
-                        }
+                    }
                 }
+                .animation(Theme.Animation.snappy, value: profileEmoji)
+                .animation(Theme.Animation.snappy, value: profileImage)
+
+                avatarMenu
             }
-            .animation(Theme.Animation.snappy, value: profileEmoji)
-            .animation(Theme.Animation.snappy, value: profileImage)
 
             Text(displayName.isEmpty ? "Your Name" : displayName)
                 .font(.system(.title3, design: .serif).weight(.bold))
@@ -291,6 +228,36 @@ struct OnboardingView: View {
                 .foregroundColor(.secondary)
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private var avatarMenu: some View {
+        Menu {
+            Button {
+                showingAvatarCustomization = true
+            } label: { Label("Choose Emoji", systemImage: "face.smiling") }
+            Button {
+                imagePickerSourceType = .photoLibrary
+                showingImagePicker = true
+            } label: { Label("Photo Library", systemImage: "photo.on.rectangle") }
+            Button {
+                imagePickerSourceType = .camera
+                showingImagePicker = true
+            } label: { Label("Take Photo", systemImage: "camera") }
+            if profileImage != nil {
+                Divider()
+                Button(role: .destructive) {
+                    profileImage = nil
+                } label: { Label("Remove Photo", systemImage: "trash") }
+            }
+        } label: {
+            Image(systemName: "pencil")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.white)
+                .frame(width: 34, height: 34)
+                .background(Color.cauldronOrange, in: Circle())
+                .overlay(Circle().strokeBorder(Color.appBackground, lineWidth: 2))
+        }
+        .accessibilityLabel("Edit avatar")
     }
 
     private var initials: String {
@@ -312,81 +279,39 @@ struct OnboardingView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func avatarOptionButton(icon: String, label: String, selected: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            VStack(spacing: 6) {
-                Image(systemName: icon)
-                    .font(.title3)
-                Text(label)
-                    .font(.caption)
-                    .fontWeight(.medium)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, Theme.Spacing.sm)
-            .background(
-                selected ? Color.cauldronOrange.opacity(0.15) : Color.appSurface,
-                in: RoundedRectangle(cornerRadius: Theme.Radius.card)
-            )
-            .foregroundColor(selected ? .cauldronOrange : .primary)
-        }
-        .buttonStyle(PressableScaleStyle())
-    }
-
-    // MARK: - Footer
-
     private var footer: some View {
         HStack(spacing: Theme.Spacing.md) {
-            if step != .welcome {
-                Button {
-                    withAnimation(Theme.Animation.spring) { goBack() }
-                } label: {
-                    Text("Back")
-                        .font(.headline)
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.glass)
-                .controlSize(.extraLarge)
+            Button {
+                withAnimation(Theme.Animation.spring) { step = .welcome }
+            } label: {
+                Text("Back")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
             }
+            .buttonStyle(.glass)
+            .controlSize(.extraLarge)
 
             Button {
-                advance()
+                Task { await createUser() }
             } label: {
-                HStack(spacing: Theme.Spacing.xs) {
+                Group {
                     if isCreating {
                         ProgressView().tint(.white)
                     } else {
-                        Text(isLastStep ? "Create Profile" : "Continue")
+                        Text("Create Profile")
                             .font(.headline)
-                        Image(systemName: isLastStep ? "checkmark" : "arrow.right")
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.85)
                     }
                 }
                 .frame(maxWidth: .infinity)
             }
             .buttonStyle(.glassProminent)
             .controlSize(.extraLarge)
-            .tint(canAdvance ? .cauldronOrange : .gray)
-            .disabled(!canAdvance || isCreating)
+            .tint(isValid ? .cauldronOrange : .gray)
+            .disabled(!isValid || isCreating)
         }
         .padding(Theme.Spacing.lg)
-    }
-
-    // MARK: - Navigation
-
-    private func goBack() {
-        guard let prev = Step(rawValue: step.rawValue - 1) else { return }
-        step = prev
-    }
-
-    private func advance() {
-        guard canAdvance else { return }
-        if isLastStep {
-            Task { await createUser() }
-        } else {
-            Haptics.light()
-            withAnimation(Theme.Animation.spring) {
-                step = Step(rawValue: step.rawValue + 1) ?? step
-            }
-        }
     }
 
     // MARK: - Actions (unchanged logic)

--- a/Cauldron/Features/Settings/OnboardingView.swift
+++ b/Cauldron/Features/Settings/OnboardingView.swift
@@ -7,10 +7,41 @@
 
 import SwiftUI
 
-/// Onboarding view for first-time users to set up their profile
+/// First-run profile setup, presented as a short guided multi-step flow
+/// (welcome → identity → avatar → referral) with a progress indicator and a
+/// live avatar preview, rather than one long scrolling form.
 struct OnboardingView: View {
     let dependencies: DependencyContainer
     let onComplete: () -> Void
+
+    // MARK: - Step model
+
+    private enum Step: Int, CaseIterable {
+        case welcome, identity, avatar, referral
+
+        var title: String {
+            switch self {
+            case .welcome: return "Welcome to Cauldron"
+            case .identity: return "Who are you?"
+            case .avatar: return "Make it yours"
+            case .referral: return "Almost there"
+            }
+        }
+
+        var subtitle: String {
+            switch self {
+            case .welcome: return "Your recipes, beautifully organized — and shared with friends."
+            case .identity: return "Pick a username and a name others will see."
+            case .avatar: return "Choose an emoji or photo for your profile."
+            case .referral: return "Got a code from a friend? Add it to connect instantly."
+            }
+        }
+    }
+
+    @State private var step: Step = .welcome
+    @Namespace private var stepGlass
+
+    // MARK: - Profile state
 
     @State private var username = ""
     @State private var displayName = ""
@@ -25,313 +56,350 @@ struct OnboardingView: View {
     @State private var referralCode = ""
     @State private var didAutoApplyReferralCode = false
 
-    // Track if user has selected a photo (to show different preview)
     private var hasPhoto: Bool { profileImage != nil }
     private var hasEmoji: Bool { profileEmoji != nil }
 
-    var isValid: Bool {
+    /// Whether the current step's requirements are satisfied (gates Continue).
+    private var canAdvance: Bool {
+        switch step {
+        case .welcome, .avatar, .referral:
+            return true
+        case .identity:
+            return isValid
+        }
+    }
+
+    private var isValid: Bool {
         username.count >= 3 && username.count <= 20 &&
         displayName.count >= 1 &&
         username.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
     }
-    
+
+    private var isLastStep: Bool { step == Step.allCases.last }
+
+    // MARK: - Body
+
     var body: some View {
-        NavigationStack {
+        VStack(spacing: 0) {
+            progressHeader
+
             ScrollView {
-                VStack(spacing: 32) {
-                    Spacer()
+                VStack(alignment: .leading, spacing: Theme.Spacing.xl) {
+                    stepHeader
 
-                    // Welcome illustration
-                    VStack(spacing: 16) {
-                        // App logo instead of profile preview
-                        Image("BrandMarks/CauldronIcon")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 100, height: 100)
-
-                        Text("Welcome to Cauldron")
-                            .font(.largeTitle)
-                            .fontWeight(.bold)
-
-                        Text("Let's set up your profile")
-                            .font(.title3)
-                            .foregroundColor(.secondary)
+                    switch step {
+                    case .welcome: welcomeStep
+                    case .identity: identityStep
+                    case .avatar: avatarStep
+                    case .referral: referralStep
                     }
 
-                    // Profile form
-                    VStack(spacing: 24) {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Username")
-                                .font(.headline)
-                                .foregroundColor(.secondary)
-
-                            TextField("username", text: $username)
-                                .textInputAutocapitalization(.never)
-                                .autocorrectionDisabled()
-                                .textCase(.lowercase)
-                                .padding()
-                                .background(Color.cauldronSecondaryBackground)
-                                .cornerRadius(12)
-
-                            Text("3-20 characters, letters, numbers, and underscores only")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Display Name")
-                                .font(.headline)
-                                .foregroundColor(.secondary)
-
-                            TextField("Your Name", text: $displayName)
-                                .textInputAutocapitalization(.words)
-                                .padding()
-                                .background(Color.cauldronSecondaryBackground)
-                                .cornerRadius(12)
-
-                            Text("This is how others will see you")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-
-                        // Avatar selection - capsule-style buttons matching RecipeDetailView
-                        VStack(alignment: .leading, spacing: 12) {
-                            Text("Profile Avatar")
-                                .font(.headline)
-                                .foregroundColor(.secondary)
-
-                            // Horizontal button row for all avatar options
-                            HStack(spacing: 10) {
-                                // Emoji Avatar Button
-                                Button {
-                                    showingAvatarCustomization = true
-                                } label: {
-                                    HStack(spacing: 6) {
-                                        Image(systemName: "face.smiling")
-                                        Text(hasEmoji ? "Edit Emoji" : "Emoji")
-                                        if hasEmoji && !hasPhoto {
-                                            Image(systemName: "checkmark")
-                                                .font(.caption2)
-                                                .fontWeight(.bold)
-                                        }
-                                    }
-                                    .font(.caption)
-                                    .fontWeight(.medium)
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 10)
-                                    .background(hasEmoji && !hasPhoto ? Color.cauldronOrange.opacity(0.15) : Color.cauldronSecondaryBackground)
-                                    .foregroundColor(hasEmoji && !hasPhoto ? .cauldronOrange : .primary)
-                                    .clipShape(Capsule())
-                                }
-                                .buttonStyle(.plain)
-
-                                // Photo Library Button
-                                Button {
-                                    imagePickerSourceType = .photoLibrary
-                                    showingImagePicker = true
-                                } label: {
-                                    HStack(spacing: 6) {
-                                        Image(systemName: "photo.on.rectangle")
-                                        Text("Photos")
-                                        if hasPhoto {
-                                            Image(systemName: "checkmark")
-                                                .font(.caption2)
-                                                .fontWeight(.bold)
-                                        }
-                                    }
-                                    .font(.caption)
-                                    .fontWeight(.medium)
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 10)
-                                    .background(hasPhoto ? Color.cauldronOrange.opacity(0.15) : Color.cauldronSecondaryBackground)
-                                    .foregroundColor(hasPhoto ? .cauldronOrange : .primary)
-                                    .clipShape(Capsule())
-                                }
-                                .buttonStyle(.plain)
-
-                                // Camera Button
-                                Button {
-                                    imagePickerSourceType = .camera
-                                    showingImagePicker = true
-                                } label: {
-                                    HStack(spacing: 6) {
-                                        Image(systemName: "camera")
-                                        Text("Camera")
-                                    }
-                                    .font(.caption)
-                                    .fontWeight(.medium)
-                                    .frame(maxWidth: .infinity)
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 10)
-                                    .background(Color.cauldronSecondaryBackground)
-                                    .foregroundColor(.primary)
-                                    .clipShape(Capsule())
-                                }
-                                .buttonStyle(.plain)
-                            }
-
-                            // Show selected photo preview with remove option
-                            if let image = profileImage {
-                                HStack(spacing: 12) {
-                                    Image(uiImage: image)
-                                        .resizable()
-                                        .scaledToFill()
-                                        .frame(width: 44, height: 44)
-                                        .clipShape(Circle())
-                                    
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text("Photo selected")
-                                            .font(.subheadline)
-                                            .fontWeight(.medium)
-                                        Text("Tap × to remove")
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                    }
-                                    
-                                    Spacer()
-                                    
-                                    Button {
-                                        profileImage = nil
-                                    } label: {
-                                        Image(systemName: "xmark.circle.fill")
-                                            .font(.title2)
-                                            .foregroundColor(.secondary)
-                                    }
-                                }
-                                .padding(12)
-                                .background(Color.cauldronOrange.opacity(0.1))
-                                .clipShape(RoundedRectangle(cornerRadius: 12))
-                            }
-                            
-                            // Show selected emoji preview
-                            if let emoji = profileEmoji, !hasPhoto {
-                                HStack(spacing: 12) {
-                                    Text(emoji)
-                                        .font(.system(size: 32))
-
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text("Emoji avatar selected")
-                                            .font(.subheadline)
-                                            .fontWeight(.medium)
-                                        Text("Tap Emoji to change")
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
-                                    }
-
-                                    Spacer()
-                                }
-                                .padding(12)
-                                .background(Color.cauldronOrange.opacity(0.1))
-                                .clipShape(RoundedRectangle(cornerRadius: 12))
-                            }
-                        }
-
-                        // Referral code section (always visible)
-                        VStack(alignment: .leading, spacing: 8) {
-                            HStack(spacing: 8) {
-                                Image(systemName: "gift.fill")
-                                    .foregroundColor(.cauldronOrange)
-                                Text("Referral Code")
-                                    .font(.headline)
-                                    .foregroundColor(.secondary)
-                            }
-
-                            TextField("Enter friend's code (optional)", text: $referralCode)
-                                .textInputAutocapitalization(.characters)
-                                .autocorrectionDisabled()
-                                .padding()
-                                .background(Color.cauldronSecondaryBackground)
-                                .cornerRadius(12)
-
-                            Text("Got a code from a friend? Enter it to unlock an exclusive icon and connect instantly!")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-
-                            if didAutoApplyReferralCode {
-                                Text("Invite code applied from your link.")
-                                    .font(.caption)
-                                    .foregroundColor(.green)
-                            }
-                        }
-
-                        if let error = errorMessage {
-                            Text(error)
-                                .font(.caption)
-                                .foregroundColor(.red)
-                                .padding()
-                                .frame(maxWidth: .infinity)
-                                .background(Color.red.opacity(0.1))
-                                .cornerRadius(8)
-                        }
+                    if let error = errorMessage {
+                        Label(error, systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                            .padding(Theme.Spacing.sm)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color.red.opacity(0.1), in: RoundedRectangle(cornerRadius: Theme.Radius.small))
                     }
-                    .padding(.horizontal)
-
-                    Spacer()
-
-                    // Continue button with glass effect like Cook button
-                    Button {
-                        Task {
-                            await createUser()
-                        }
-                    } label: {
-                        HStack(spacing: 8) {
-                            if isCreating {
-                                ProgressView()
-                                    .tint(.white)
-                            } else {
-                                Image(systemName: "arrow.right.circle.fill")
-                                    .font(.body)
-                                Text("Get Started")
-                                    .font(.subheadline)
-                                    .fontWeight(.semibold)
-                            }
-                        }
-                    }
-                    .buttonStyle(.glassProminent)
-                    .tint(isValid ? .cauldronOrange : .gray)
-                    .disabled(!isValid || isCreating)
-                    .padding(.bottom, 32)
                 }
+                .padding(Theme.Spacing.lg)
             }
-            .navigationBarHidden(true)
-            .sheet(isPresented: $showingAvatarCustomization) {
-                AvatarCustomizationSheet(
-                    selectedEmoji: $profileEmoji,
-                    selectedColor: $profileColor
-                )
+
+            footer
+        }
+        .background(Color.appBackground.ignoresSafeArea())
+        .sheet(isPresented: $showingAvatarCustomization) {
+            AvatarCustomizationSheet(selectedEmoji: $profileEmoji, selectedColor: $profileColor)
+        }
+        .fullScreenCover(isPresented: $showingImagePicker) {
+            ImagePicker(image: $profileImage, sourceType: imagePickerSourceType)
+                .ignoresSafeArea()
+        }
+        .task {
+            if let pendingCode = await PendingReferralManager.shared.consumePendingCode() {
+                applyIncomingReferralCode(pendingCode)
             }
-            // Use fullScreenCover for camera to prevent white bar at bottom of viewfinder
-            .fullScreenCover(isPresented: $showingImagePicker) {
-                ImagePicker(image: $profileImage, sourceType: imagePickerSourceType)
-                    .ignoresSafeArea()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openReferralInvite)) { notification in
+            guard let code = notification.object as? String else { return }
+            applyIncomingReferralCode(code)
+            // Jump to the referral step so the user sees it was applied.
+            withAnimation(Theme.Animation.spring) { step = .referral }
+        }
+    }
+
+    // MARK: - Header / progress
+
+    private var progressHeader: some View {
+        HStack(spacing: Theme.Spacing.xs) {
+            ForEach(Step.allCases, id: \.rawValue) { s in
+                Capsule()
+                    .fill(s.rawValue <= step.rawValue ? Color.cauldronOrange : Color.appSeparator)
+                    .frame(height: 4)
+                    .animation(Theme.Animation.spring, value: step)
             }
-            .task {
-                if let pendingCode = await PendingReferralManager.shared.consumePendingCode() {
-                    applyIncomingReferralCode(pendingCode)
-                }
+        }
+        .padding(.horizontal, Theme.Spacing.lg)
+        .padding(.top, Theme.Spacing.md)
+    }
+
+    private var stepHeader: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            Text(step.title)
+                .font(.system(.largeTitle, design: .serif).weight(.bold))
+            Text(step.subtitle)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Steps
+
+    private var welcomeStep: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Image("BrandMarks/CauldronIcon")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 140, height: 140)
+                .shadow(color: .cauldronOrange.opacity(0.25), radius: 20, y: 8)
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                onboardingHighlight("square.and.arrow.down", "Import from the web, YouTube, TikTok & more")
+                onboardingHighlight("flame.fill", "Cook hands-free with step timers")
+                onboardingHighlight("person.2.fill", "Share recipes with friends")
             }
-            .onReceive(NotificationCenter.default.publisher(for: .openReferralInvite)) { notification in
-                guard let code = notification.object as? String else { return }
-                applyIncomingReferralCode(code)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.top, Theme.Spacing.md)
+    }
+
+    private func onboardingHighlight(_ icon: String, _ text: String) -> some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: icon)
+                .font(.headline)
+                .foregroundStyle(Color.cauldronOrange)
+                .frame(width: 28)
+            Text(text)
+                .font(.subheadline)
+            Spacer()
+        }
+    }
+
+    private var identityStep: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            avatarPreview
+
+            fieldGroup(title: "Username", caption: "3–20 characters · letters, numbers, underscores") {
+                TextField("username", text: $username)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .textCase(.lowercase)
+            }
+
+            fieldGroup(title: "Display Name", caption: "This is how others will see you") {
+                TextField("Your Name", text: $displayName)
+                    .textInputAutocapitalization(.words)
             }
         }
     }
-    
+
+    private var avatarStep: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            avatarPreview
+
+            HStack(spacing: Theme.Spacing.sm) {
+                avatarOptionButton(icon: "face.smiling", label: hasEmoji ? "Edit Emoji" : "Emoji", selected: hasEmoji && !hasPhoto) {
+                    showingAvatarCustomization = true
+                }
+                avatarOptionButton(icon: "photo.on.rectangle", label: "Photos", selected: hasPhoto) {
+                    imagePickerSourceType = .photoLibrary
+                    showingImagePicker = true
+                }
+                avatarOptionButton(icon: "camera", label: "Camera", selected: false) {
+                    imagePickerSourceType = .camera
+                    showingImagePicker = true
+                }
+            }
+
+            if hasPhoto {
+                Button(role: .destructive) {
+                    withAnimation(Theme.Animation.snappy) { profileImage = nil }
+                } label: {
+                    Label("Remove photo", systemImage: "xmark.circle.fill")
+                        .font(.subheadline)
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+    }
+
+    private var referralStep: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            avatarPreview
+
+            fieldGroup(title: "Referral Code", caption: "Optional — unlocks an exclusive icon and connects you instantly.") {
+                TextField("Enter friend's code", text: $referralCode)
+                    .textInputAutocapitalization(.characters)
+                    .autocorrectionDisabled()
+            }
+
+            if didAutoApplyReferralCode {
+                Label("Invite code applied from your link.", systemImage: "checkmark.seal.fill")
+                    .font(.caption)
+                    .foregroundColor(.green)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    // MARK: - Shared step components
+
+    /// Live avatar + name preview shown across the profile-building steps.
+    private var avatarPreview: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            ZStack {
+                if let image = profileImage {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 96, height: 96)
+                        .clipShape(Circle())
+                } else {
+                    Circle()
+                        .fill((profileColor.flatMap { Color(hex: $0) } ?? .cauldronOrange).opacity(0.15))
+                        .frame(width: 96, height: 96)
+                        .overlay {
+                            if let emoji = profileEmoji {
+                                Text(emoji).font(.system(size: 44))
+                            } else {
+                                Text(initials)
+                                    .font(.system(.title, design: .serif).weight(.semibold))
+                                    .foregroundColor(profileColor.flatMap { Color(hex: $0) } ?? .cauldronOrange)
+                            }
+                        }
+                }
+            }
+            .animation(Theme.Animation.snappy, value: profileEmoji)
+            .animation(Theme.Animation.snappy, value: profileImage)
+
+            Text(displayName.isEmpty ? "Your Name" : displayName)
+                .font(.system(.title3, design: .serif).weight(.bold))
+            Text("@\(username.isEmpty ? "username" : username)")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var initials: String {
+        displayName.isEmpty ? "?" : String(displayName.prefix(2)).uppercased()
+    }
+
+    private func fieldGroup<Content: View>(title: String, caption: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            Text(title)
+                .font(.headline)
+                .foregroundColor(.secondary)
+            content()
+                .padding()
+                .background(Color.appSurface, in: RoundedRectangle(cornerRadius: Theme.Radius.card))
+            Text(caption)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func avatarOptionButton(icon: String, label: String, selected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.title3)
+                Text(label)
+                    .font(.caption)
+                    .fontWeight(.medium)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Theme.Spacing.sm)
+            .background(
+                selected ? Color.cauldronOrange.opacity(0.15) : Color.appSurface,
+                in: RoundedRectangle(cornerRadius: Theme.Radius.card)
+            )
+            .foregroundColor(selected ? .cauldronOrange : .primary)
+        }
+        .buttonStyle(PressableScaleStyle())
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            if step != .welcome {
+                Button {
+                    withAnimation(Theme.Animation.spring) { goBack() }
+                } label: {
+                    Text("Back")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.glass)
+                .controlSize(.extraLarge)
+            }
+
+            Button {
+                advance()
+            } label: {
+                HStack(spacing: Theme.Spacing.xs) {
+                    if isCreating {
+                        ProgressView().tint(.white)
+                    } else {
+                        Text(isLastStep ? "Create Profile" : "Continue")
+                            .font(.headline)
+                        Image(systemName: isLastStep ? "checkmark" : "arrow.right")
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.glassProminent)
+            .controlSize(.extraLarge)
+            .tint(canAdvance ? .cauldronOrange : .gray)
+            .disabled(!canAdvance || isCreating)
+        }
+        .padding(Theme.Spacing.lg)
+    }
+
+    // MARK: - Navigation
+
+    private func goBack() {
+        guard let prev = Step(rawValue: step.rawValue - 1) else { return }
+        step = prev
+    }
+
+    private func advance() {
+        guard canAdvance else { return }
+        if isLastStep {
+            Task { await createUser() }
+        } else {
+            Haptics.light()
+            withAnimation(Theme.Animation.spring) {
+                step = Step(rawValue: step.rawValue + 1) ?? step
+            }
+        }
+    }
+
+    // MARK: - Actions (unchanged logic)
+
     @MainActor
     private func createUser() async {
         isCreating = true
         errorMessage = nil
 
         do {
-            // Normalize username: trim whitespace and convert to lowercase for consistency
-            // Trim display name whitespace
             let normalizedUsername = username.trimmingCharacters(in: .whitespaces).lowercased()
             let normalizedDisplayName = displayName.trimmingCharacters(in: .whitespaces)
 
-            // Photo takes precedence over emoji - if user selected a photo, use it
-            // Otherwise, use the emoji they selected
             try await CurrentUserSession.shared.createUser(
                 username: normalizedUsername,
                 displayName: normalizedDisplayName,
@@ -341,12 +409,12 @@ struct OnboardingView: View {
                 dependencies: dependencies
             )
 
-            // Process referral code if provided
             let trimmedCode = referralCode.trimmingCharacters(in: .whitespaces)
             if !trimmedCode.isEmpty {
                 await processReferralCode(trimmedCode, displayName: normalizedDisplayName)
             }
 
+            Haptics.success()
             onComplete()
         } catch {
             errorMessage = error.localizedDescription
@@ -354,7 +422,6 @@ struct OnboardingView: View {
         }
     }
 
-    /// Process a referral code: look up referrer, create auto-friend connection, increment count
     @MainActor
     private func processReferralCode(_ code: String, displayName: String) async {
         ReferralManager.shared.configure(userCloudService: dependencies.userCloudService, connectionCloudService: dependencies.connectionCloudService)

--- a/Cauldron/Features/Settings/OnboardingView.swift
+++ b/Cauldron/Features/Settings/OnboardingView.swift
@@ -34,6 +34,7 @@ struct OnboardingView: View {
     @State private var imagePickerSourceType: UIImagePickerController.SourceType = .photoLibrary
     @State private var referralCode = ""
     @State private var didAutoApplyReferralCode = false
+    @State private var showReferralField = false
 
     private var isValid: Bool {
         username.count >= 3 && username.count <= 20 &&
@@ -167,10 +168,22 @@ struct OnboardingView: View {
                             .textInputAutocapitalization(.words)
                     }
 
-                    fieldGroup(title: "Referral Code", caption: didAutoApplyReferralCode ? "Applied from your invite link." : "Optional — connect with a friend instantly.") {
-                        TextField("Enter code", text: $referralCode)
-                            .textInputAutocapitalization(.characters)
-                            .autocorrectionDisabled()
+                    if showReferralField || didAutoApplyReferralCode {
+                        fieldGroup(title: "Referral Code", caption: didAutoApplyReferralCode ? "Applied from your invite link." : "Connect with a friend instantly.") {
+                            TextField("Enter code", text: $referralCode)
+                                .textInputAutocapitalization(.characters)
+                                .autocorrectionDisabled()
+                        }
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                    } else {
+                        Button {
+                            withAnimation(Theme.Animation.snappy) { showReferralField = true }
+                        } label: {
+                            Label("Add referral code", systemImage: "gift")
+                                .font(.subheadline)
+                                .foregroundStyle(Color.cauldronOrange)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
                     if let error = errorMessage {

--- a/Cauldron/Features/Sharing/AllFriendsListViews.swift
+++ b/Cauldron/Features/Sharing/AllFriendsListViews.swift
@@ -88,6 +88,8 @@ struct AllFriendsRecipesListView: View {
 struct AllFriendsCollectionsListView: View {
     let collections: [Collection]
     let dependencies: DependencyContainer
+    /// Resolves a collection's owner so cards can show a creator tag (optional).
+    var ownerProvider: ((Collection) -> User?)? = nil
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var collectionImageCache: [UUID: [URL?]] = [:]
@@ -104,6 +106,7 @@ struct AllFriendsCollectionsListView: View {
                             collection: collection,
                             recipeImages: collectionImageCache[collection.id] ?? [],
                             preferredWidth: nil,
+                            owner: ownerProvider?(collection),
                             dependencies: dependencies
                         )
                     }

--- a/Cauldron/Features/Sharing/FriendsTabView.swift
+++ b/Cauldron/Features/Sharing/FriendsTabView.swift
@@ -480,7 +480,8 @@ struct FriendsTabView: View {
 
                 NavigationLink(destination: AllFriendsCollectionsListView(
                     collections: viewModel.sharedCollections,
-                    dependencies: dependencies
+                    dependencies: dependencies,
+                    ownerProvider: { viewModel.owner(for: $0) }
                 )) {
                     Text("See All")
                         .font(.subheadline)

--- a/Cauldron/Info.plist
+++ b/Cauldron/Info.plist
@@ -24,7 +24,7 @@
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>
-		<string></string>
+		<string>LaunchBackground</string>
 		<key>UIImageName</key>
 		<string>BrandMarks/CauldronIconSmall</string>
 		<key>UIImageRespectsSafeAreaInsets</key>

--- a/CauldronTests/Parsing/QuantityTextParserTests.swift
+++ b/CauldronTests/Parsing/QuantityTextParserTests.swift
@@ -1,0 +1,64 @@
+//
+//  QuantityTextParserTests.swift
+//  CauldronTests
+//
+
+import XCTest
+@testable import Cauldron
+
+final class QuantityTextParserTests: XCTestCase {
+
+    func testEmptyAndWhitespaceReturnNil() {
+        XCTAssertNil(QuantityTextParser.parse(""))
+        XCTAssertNil(QuantityTextParser.parse("   "))
+    }
+
+    func testWholeNumber() {
+        let result = QuantityTextParser.parse("2")
+        XCTAssertEqual(result?.value ?? .nan, 2, accuracy: 0.001)
+        XCTAssertNil(result?.upperValue)
+    }
+
+    func testDecimal() {
+        let result = QuantityTextParser.parse("1.5")
+        XCTAssertEqual(result?.value ?? .nan, 1.5, accuracy: 0.001)
+        XCTAssertNil(result?.upperValue)
+    }
+
+    func testSimpleFraction() {
+        let result = QuantityTextParser.parse("1/2")
+        XCTAssertEqual(result?.value ?? .nan, 0.5, accuracy: 0.001)
+    }
+
+    func testMixedNumber() {
+        let result = QuantityTextParser.parse("1 1/2")
+        XCTAssertEqual(result?.value ?? .nan, 1.5, accuracy: 0.001)
+    }
+
+    func testRange() {
+        let result = QuantityTextParser.parse("1-2")
+        XCTAssertEqual(result?.value ?? .nan, 1, accuracy: 0.001)
+        XCTAssertEqual(result?.upperValue ?? 0, 2, accuracy: 0.001)
+    }
+
+    func testRangeWithSpaces() {
+        let result = QuantityTextParser.parse("1 - 2")
+        XCTAssertEqual(result?.value ?? .nan, 1, accuracy: 0.001)
+        XCTAssertEqual(result?.upperValue ?? 0, 2, accuracy: 0.001)
+    }
+
+    func testRangeOfFractions() {
+        let result = QuantityTextParser.parse("1/2-3/4")
+        XCTAssertEqual(result?.value ?? 0, 0.5, accuracy: 0.001)
+        XCTAssertEqual(result?.upperValue ?? 0, 0.75, accuracy: 0.001)
+    }
+
+    func testDivideByZeroFractionIsNotANumber() {
+        // "1/0" is not a valid quantity → nil
+        XCTAssertNil(QuantityTextParser.parse("1/0"))
+    }
+
+    func testGarbageReturnsNil() {
+        XCTAssertNil(QuantityTextParser.parse("abc"))
+    }
+}


### PR DESCRIPTION
A broad design + scalability sweep across the app, building on the earlier ui-polish work. **23 commits, 27 files, net −73 lines** — it adds polish while shrinking the codebase.

## Design language
- **Liquid Glass, done natively** — converted surfaces and buttons to real `glassEffect` / `.buttonStyle(.glass)` / `.glassProminent`, with adjacent/scrolling glass wrapped in `GlassEffectContainer` so it stops morphing and floating over chrome (collections Edit/Add, cook-mode pills, AI surfaces, profile/tier cards).
- **Serif editorial voice** — New York serif for nav titles and section headers, warm token palette (`appBackground`/`appSurface`/…), `.warmCanvas()` paper backdrop on cook mode and the launch screen.
- **`.toolbarTitleDisplayMode(.inlineLarge)`** titles matched to the serif section headers.

## Screens reworked
- **Onboarding** → a cleaner 2-step flow: welcome hero + "Create your profile" (avatar pencil-menu, live name preview, referral collapsed into an "Add referral code" disclosure, one-line CTA).
- **AI generator** → decluttered to a warm "What are you craving?" hero, a gently rotating placeholder for ambient inspiration, a one-tap "Surprise me", categories behind a "Refine with categories" disclosure, and a single morphing primary action (Generate → generating → Save).
- **Tier roadmap** → glass cards, glass-highlighted current tier, trimmed copy, animated progress + AI-generate entry.
- **Collection detail** → extracted `CollectionCoverView` paged carousel; glass Edit/Add buttons.
- **Profile / Edit profile** → glass cards, serif name, avatar pencil-menu (removed the separate avatar section).

## Delight
- Favorite-star bounce + haptic, timer-done flash + success haptic, animated tier progress fill / icon pop / pulsing crown.
- Removed the "Nicely done" cook-complete celebration (read as tacky).

## Scalability / refactors
- Extracted `CollectionCoverView`, `AIGeneratorComponents` (streaming preview, error card, mesh gradient), and `QuantityTextParser` (with 10 new tests) out of oversized views/view models.
- `UnitConverter` marked `nonisolated`.
- Added debug launch flags (`--cauldron-show-onboarding`, `--cauldron-ai-preview`) to preview otherwise-unreachable screens.

## Verification
- Full test suite green: **699 passed, 0 failed, 1 skipped**.
- Visual QA sweep in the iPhone 17 Pro simulator across onboarding, cook tab, recipe detail, cook mode, profile, tier roadmap, AI generator, and collection detail — no regressions.

### Known caveat
The AI generator's **generating → Save** path could only be verified for layout via the preview flag; actual generation needs a real Apple-Intelligence device (the simulator returns a generation error, which the new error card handles gracefully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)