### PR TITLE
Design language: legible tier color, glass surfaces, color & radius tokens

### DIFF
--- a/Cauldron/Core/Components/ImportPreviewSheet.swift
+++ b/Cauldron/Core/Components/ImportPreviewSheet.swift
@@ -160,7 +160,7 @@ struct ImportPreviewSheet: View {
                     ownerId: recipe.ownerId
                 )
                 .frame(height: 250)
-                .cornerRadius(12)
+                .cornerRadius(Theme.Radius.card)
                 .padding(.horizontal)
                 .task(id: recipe.id) {
                     // Task will automatically cancel when recipe.id changes
@@ -193,7 +193,7 @@ struct ImportPreviewSheet: View {
                                         .padding(.vertical, 6)
                                         .background(Color.cauldronOrange.opacity(0.2))
                                         .foregroundColor(.cauldronOrange)
-                                        .cornerRadius(12)
+                                        .cornerRadius(Theme.Radius.card)
                                 }
                             }
                             .padding(.horizontal)
@@ -240,7 +240,7 @@ struct ImportPreviewSheet: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(Color.cauldronOrange)
-                    .cornerRadius(12)
+                    .cornerRadius(Theme.Radius.card)
                 }
                 .disabled(isImporting)
                 .padding(.horizontal)
@@ -299,7 +299,7 @@ struct ImportPreviewSheet: View {
                 .frame(maxWidth: .infinity)
                 .padding()
                 .background(Color.secondary)
-                .cornerRadius(12)
+                .cornerRadius(Theme.Radius.card)
             }
             .padding(.horizontal)
 
@@ -331,7 +331,7 @@ struct ImportPreviewSheet: View {
                             placeholderImage
                         }
                     }
-                    .cornerRadius(12)
+                    .cornerRadius(Theme.Radius.card)
                     .padding(.horizontal)
                 }
 
@@ -366,7 +366,7 @@ struct ImportPreviewSheet: View {
                     .frame(maxWidth: .infinity)
                     .padding()
                     .background(Color.cauldronOrange)
-                    .cornerRadius(12)
+                    .cornerRadius(Theme.Radius.card)
                 }
                 .disabled(isImporting)
                 .padding(.horizontal)

--- a/Cauldron/Core/Components/ImportPreviewSheet.swift
+++ b/Cauldron/Core/Components/ImportPreviewSheet.swift
@@ -120,7 +120,7 @@ struct ImportPreviewSheet: View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 48))
-                .foregroundColor(.orange)
+                .foregroundColor(.cauldronOrange)
             Text("Unable to Load")
                 .font(.title2)
                 .fontWeight(.semibold)
@@ -191,8 +191,8 @@ struct ImportPreviewSheet: View {
                                         .font(.caption)
                                         .padding(.horizontal, 12)
                                         .padding(.vertical, 6)
-                                        .background(Color.orange.opacity(0.2))
-                                        .foregroundColor(.orange)
+                                        .background(Color.cauldronOrange.opacity(0.2))
+                                        .foregroundColor(.cauldronOrange)
                                         .cornerRadius(12)
                                 }
                             }
@@ -239,7 +239,7 @@ struct ImportPreviewSheet: View {
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background(Color.orange)
+                    .background(Color.cauldronOrange)
                     .cornerRadius(12)
                 }
                 .disabled(isImporting)
@@ -365,7 +365,7 @@ struct ImportPreviewSheet: View {
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background(Color.orange)
+                    .background(Color.cauldronOrange)
                     .cornerRadius(12)
                 }
                 .disabled(isImporting)

--- a/Cauldron/Core/Components/TagView.swift
+++ b/Cauldron/Core/Components/TagView.swift
@@ -72,9 +72,9 @@ struct TagView: View {
         .padding(.vertical, 6)
         .background(color.opacity(isSelected ? 0.25 : 0.15))
         .foregroundColor(color)
-        .cornerRadius(20)
+        .cornerRadius(Theme.Radius.xLarge)
         .overlay(
-            RoundedRectangle(cornerRadius: 20)
+            RoundedRectangle(cornerRadius: Theme.Radius.xLarge)
                 .stroke(color, lineWidth: isSelected ? 1.5 : 0)
         )
         // Collapse into a single labeled element only for display-only tags.

--- a/Cauldron/Core/Components/TierBadgeView.swift
+++ b/Cauldron/Core/Components/TierBadgeView.swift
@@ -52,7 +52,7 @@ struct TierBadgeView: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(tier.color.opacity(0.15))
-        .cornerRadius(8)
+        .cornerRadius(Theme.Radius.small)
     }
 
     // MARK: - Expanded Style (Icon + name + boost)

--- a/Cauldron/Core/Components/TierProgressView.swift
+++ b/Cauldron/Core/Components/TierProgressView.swift
@@ -80,7 +80,7 @@ struct TierProgressView: View {
             }
             .padding(12)
             .background(Color.cauldronSecondaryBackground)
-            .cornerRadius(12)
+            .cornerRadius(Theme.Radius.card)
         }
         .buttonStyle(.plain)
         .disabled(showViewAllTiers == nil)

--- a/Cauldron/Core/Services/UserTierManager.swift
+++ b/Cauldron/Core/Services/UserTierManager.swift
@@ -42,7 +42,7 @@ enum UserTier: Int, CaseIterable, Comparable {
         case .apprentice: return Color(hex: "#8E8E93") ?? .gray         // Gray
         case .potionMaker: return Color(hex: "#CD7F32") ?? .orange      // Bronze
         case .spellCaster: return Color(hex: "#FF3B30") ?? .red         // Red
-        case .grandWizard: return Color(hex: "#FFD700") ?? .yellow      // Gold
+        case .grandWizard: return Color(hex: "#E8A317") ?? .orange      // Amber gold (legible on light)
         case .legendarySorcerer: return Color(hex: "#AF52DE") ?? .purple // Purple
         }
     }

--- a/Cauldron/Features/AIGenerator/AIGeneratorComponents.swift
+++ b/Cauldron/Features/AIGenerator/AIGeneratorComponents.swift
@@ -51,7 +51,7 @@ struct AIUnavailableCard: View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 44))
-                .foregroundColor(.orange)
+                .foregroundColor(.cauldronOrange)
 
             Text("Apple Intelligence Not Available")
                 .font(.headline)
@@ -79,7 +79,7 @@ struct AnimatedMeshGradient: View {
             GeometryReader { proxy in
                 ZStack {
                     Circle()
-                        .fill(Color.orange.opacity(0.15))
+                        .fill(Color.cauldronOrange.opacity(0.15))
                         .frame(width: proxy.size.width * 0.8)
                         .blur(radius: 60)
                         .offset(x: animate ? -50 : 50, y: animate ? -50 : 50)
@@ -210,7 +210,7 @@ struct AIRecipePreview: View {
                                                 )
                                             )
                                     )
-                                    .shadow(color: .orange.opacity(0.3), radius: 4, x: 0, y: 2)
+                                    .shadow(color: .cauldronOrange.opacity(0.3), radius: 4, x: 0, y: 2)
 
                                 Text(step.text?.decodingHTMLEntities ?? "")
                                     .font(.body)

--- a/Cauldron/Features/AIGenerator/AIGeneratorComponents.swift
+++ b/Cauldron/Features/AIGenerator/AIGeneratorComponents.swift
@@ -148,9 +148,7 @@ struct AIRecipePreview: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(16)
-                .background(.ultraThinMaterial)
-                .cornerRadius(20)
-                .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
+                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Theme.Radius.xLarge, style: .continuous))
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
 
@@ -181,9 +179,7 @@ struct AIRecipePreview: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(16)
-                .background(.ultraThinMaterial)
-                .cornerRadius(20)
-                .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
+                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Theme.Radius.xLarge, style: .continuous))
             }
 
             if let steps = partial.steps, !steps.isEmpty {
@@ -223,9 +219,7 @@ struct AIRecipePreview: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(16)
-                .background(.ultraThinMaterial)
-                .cornerRadius(20)
-                .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
+                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Theme.Radius.xLarge, style: .continuous))
             }
         }
     }
@@ -278,11 +272,9 @@ struct AIErrorCard: View {
             Spacer(minLength: 0)
         }
         .padding(20)
-        .background(Color.red.opacity(0.08))
-        .background(.ultraThinMaterial)
-        .cornerRadius(16)
+        .glassEffect(.regular.tint(Color.red.opacity(0.12)), in: RoundedRectangle(cornerRadius: Theme.Radius.large, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 16)
+            RoundedRectangle(cornerRadius: Theme.Radius.large, style: .continuous)
                 .stroke(Color.red.opacity(0.2), lineWidth: 1)
         )
     }

--- a/Cauldron/Features/Collections/CollectionCardView.swift
+++ b/Cauldron/Features/Collections/CollectionCardView.swift
@@ -177,7 +177,7 @@ struct CollectionCardView: View {
                 .aspectRatio(1, contentMode: .fit)
                 .clipShape(.rect(cornerRadius: 12))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 12)
+                    RoundedRectangle(cornerRadius: Theme.Radius.card)
                         .stroke(collectionColor.opacity(0.2), lineWidth: 1)
                 )
                 .overlay(alignment: .topLeading) {

--- a/Cauldron/Features/Collections/CollectionDetailView.swift
+++ b/Cauldron/Features/Collections/CollectionDetailView.swift
@@ -314,7 +314,7 @@ struct CollectionDetailView: View {
             }
             .padding()
             .background(Color.cauldronOrange.opacity(0.1))
-            .cornerRadius(12)
+            .cornerRadius(Theme.Radius.card)
         }
         .buttonStyle(PressableScaleStyle())
         .padding(.horizontal, 16)

--- a/Cauldron/Features/Collections/CollectionDetailView.swift
+++ b/Cauldron/Features/Collections/CollectionDetailView.swift
@@ -291,7 +291,7 @@ struct CollectionDetailView: View {
         } label: {
             HStack(spacing: Theme.Spacing.sm) {
                 Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundColor(.orange)
+                    .foregroundColor(.cauldronOrange)
                     .font(.title3)
 
                 VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
@@ -313,7 +313,7 @@ struct CollectionDetailView: View {
                     .font(.caption)
             }
             .padding()
-            .background(Color.orange.opacity(0.1))
+            .background(Color.cauldronOrange.opacity(0.1))
             .cornerRadius(12)
         }
         .buttonStyle(PressableScaleStyle())

--- a/Cauldron/Features/Collections/CollectionFormView.swift
+++ b/Cauldron/Features/Collections/CollectionFormView.swift
@@ -143,7 +143,7 @@ struct CollectionFormView: View {
                                 if recipe.imageURL != nil {
                                     RecipeImageView(thumbnailForRecipe: recipe, recipeImageService: dependencies.recipeImageService)
                                 } else {
-                                    RoundedRectangle(cornerRadius: 8)
+                                    RoundedRectangle(cornerRadius: Theme.Radius.small)
                                         .fill(Color.appSurface)
                                         .frame(width: 60, height: 60)
                                         .overlay(

--- a/Cauldron/Features/Collections/CollectionRecipeSelectorSheet.swift
+++ b/Cauldron/Features/Collections/CollectionRecipeSelectorSheet.swift
@@ -202,7 +202,7 @@ struct CollectionRecipeSelectorSheet: View {
                                 .font(.caption)
                                 .foregroundStyle(Color(red: 0.5, green: 0.0, blue: 0.0))
                                 .padding(6)
-                                .background(Circle().fill(.ultraThinMaterial))
+                                .glassEffect(.regular, in: Circle())
                                 .padding(6)
                         }
                     },

--- a/Cauldron/Features/Collections/ConformanceFixSheet.swift
+++ b/Cauldron/Features/Collections/ConformanceFixSheet.swift
@@ -52,7 +52,7 @@ struct ConformanceFixSheet: View {
                 VStack(alignment: .leading, spacing: 12) {
                     HStack(spacing: 12) {
                         Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundColor(.orange)
+                            .foregroundColor(.cauldronOrange)
                             .font(.title2)
 
                         VStack(alignment: .leading, spacing: 4) {
@@ -66,7 +66,7 @@ struct ConformanceFixSheet: View {
                         }
                     }
                     .padding()
-                    .background(Color.orange.opacity(0.1))
+                    .background(Color.cauldronOrange.opacity(0.1))
                     .cornerRadius(12)
                 }
                 .padding()

--- a/Cauldron/Features/Collections/ConformanceFixSheet.swift
+++ b/Cauldron/Features/Collections/ConformanceFixSheet.swift
@@ -67,7 +67,7 @@ struct ConformanceFixSheet: View {
                     }
                     .padding()
                     .background(Color.cauldronOrange.opacity(0.1))
-                    .cornerRadius(12)
+                    .cornerRadius(Theme.Radius.card)
                 }
                 .padding()
 
@@ -172,7 +172,7 @@ struct ConformanceFixSheet: View {
                         .padding()
                         .background(selectedRecipeIds.isEmpty ? Color.gray : Color.cauldronOrange)
                         .foregroundColor(.white)
-                        .cornerRadius(12)
+                        .cornerRadius(Theme.Radius.card)
                     }
                     .disabled(selectedRecipeIds.isEmpty || isUpdating)
                 }

--- a/Cauldron/Features/Collections/ConformanceFixSheet.swift
+++ b/Cauldron/Features/Collections/ConformanceFixSheet.swift
@@ -212,7 +212,7 @@ struct ConformanceFixSheet: View {
                                 .font(.caption)
                                 .foregroundStyle(Color(red: 0.5, green: 0.0, blue: 0.0))
                                 .padding(6)
-                                .background(Circle().fill(.ultraThinMaterial))
+                                .glassEffect(.regular, in: Circle())
                                 .padding(6)
                         }
                     },

--- a/Cauldron/Features/Cook/CookTabView.swift
+++ b/Cauldron/Features/Cook/CookTabView.swift
@@ -592,7 +592,7 @@ struct CookTabView: View {
         .padding(24)
         .frame(maxWidth: .infinity)
         .background(Color.cauldronSecondaryBackground)
-        .cornerRadius(16)
+        .cornerRadius(Theme.Radius.large)
         .padding(.horizontal, Theme.Spacing.md)
     }
 
@@ -818,7 +818,7 @@ struct CategoryCardView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
         .background(Color.cauldronSecondaryBackground)
-        .cornerRadius(12)
+        .cornerRadius(Theme.Radius.card)
         .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 2)
     }
 }

--- a/Cauldron/Features/CookMode/CookModeView.swift
+++ b/Cauldron/Features/CookMode/CookModeView.swift
@@ -274,7 +274,7 @@ struct CookModeView: View {
                     .padding(20)
                     .frame(maxWidth: .infinity)
                     .background(Color.cauldronSecondaryBackground)
-                    .cornerRadius(16)
+                    .cornerRadius(Theme.Radius.large)
                     .shadow(color: .black.opacity(0.05), radius: 4, x: 0, y: 2)
             }
         }
@@ -341,7 +341,7 @@ struct CookModeView: View {
                                     }
                                     .padding(16)
                                     .background(Color.cauldronSecondaryBackground)
-                                    .cornerRadius(16)
+                                    .cornerRadius(Theme.Radius.large)
                                 }
                                 .buttonStyle(.plain)
                             }

--- a/Cauldron/Features/CookMode/ImprovedTimerRowView.swift
+++ b/Cauldron/Features/CookMode/ImprovedTimerRowView.swift
@@ -75,9 +75,9 @@ struct ImprovedTimerRowView: View {
         }
         .padding(16)
         .background(didComplete ? Color.cauldronOrange.opacity(0.18) : Color.cauldronSecondaryBackground)
-        .cornerRadius(16)
+        .cornerRadius(Theme.Radius.large)
         .overlay(
-            RoundedRectangle(cornerRadius: 16)
+            RoundedRectangle(cornerRadius: Theme.Radius.large)
                 .stroke(Color.cauldronOrange.opacity(didComplete ? 0.6 : 0), lineWidth: 2)
         )
         .scaleEffect(didComplete ? 1.03 : 1.0)
@@ -176,7 +176,7 @@ struct QuickTimerButton: View {
                 .padding(.vertical, 8)
                 .background(Color.cauldronOrange.opacity(0.15))
                 .foregroundColor(.cauldronOrange)
-                .cornerRadius(8)
+                .cornerRadius(Theme.Radius.small)
         }
         .sheet(isPresented: $showingCustomTimer) {
             NavigationStack {

--- a/Cauldron/Features/Importer/ImporterView.swift
+++ b/Cauldron/Features/Importer/ImporterView.swift
@@ -360,7 +360,7 @@ struct ImporterView: View {
                 .padding(.vertical, 14)
                 .background(Color.cauldronOrange.opacity(0.12))
                 .foregroundColor(.cauldronOrange)
-                .cornerRadius(12)
+                .cornerRadius(Theme.Radius.card)
             }
 
             Text("When you tap Import Recipe, Cauldron reads the image and tries to build a complete recipe.")
@@ -398,7 +398,7 @@ struct ImporterView: View {
         }
         .padding(16)
         .background(Color.red.opacity(0.1))
-        .cornerRadius(12)
+        .cornerRadius(Theme.Radius.card)
     }
 
     private func pasteURLFromClipboard() {

--- a/Cauldron/Features/Importer/RecipeImportPreviewView.swift
+++ b/Cauldron/Features/Importer/RecipeImportPreviewView.swift
@@ -72,7 +72,7 @@ struct RecipeImportPreviewView: View {
                         }
                         .padding()
                         .background(Color.cauldronSecondaryBackground)
-                        .cornerRadius(12)
+                        .cornerRadius(Theme.Radius.card)
                         .padding(.horizontal)
                     
                     // Recipe details
@@ -115,7 +115,7 @@ struct RecipeImportPreviewView: View {
                                             .padding(.vertical, 5)
                                             .background(Color.cauldronOrange.opacity(0.15))
                                             .foregroundColor(.cauldronOrange)
-                                            .cornerRadius(8)
+                                            .cornerRadius(Theme.Radius.small)
                                     }
                                 }
                             }
@@ -320,7 +320,7 @@ struct RecipeImportPreviewView: View {
         .frame(maxWidth: .infinity)
         .padding()
         .background(Color.cauldronOrange.opacity(0.1))
-        .cornerRadius(8)
+        .cornerRadius(Theme.Radius.small)
     }
     
     

--- a/Cauldron/Features/Library/Components/RecipeHeaderSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeHeaderSection.swift
@@ -153,7 +153,7 @@ struct RecipeHeaderSection: View {
                     .font(.title3.weight(.semibold))
                     .frame(width: 36, height: 36)
                     .foregroundStyle(localIsFavorite ? .yellow : .secondary)
-                    .background(.ultraThinMaterial, in: Circle())
+                    .glassEffect(.regular, in: Circle())
                     .symbolEffect(.bounce, value: localIsFavorite)
             }
             .accessibilityLabel(localIsFavorite ? "Remove Favorite" : "Favorite")
@@ -215,7 +215,7 @@ struct RecipeHeaderSection: View {
         .foregroundColor(.secondary)
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
-        .background(.ultraThinMaterial, in: Capsule())
+        .glassEffect(.regular, in: Capsule())
     }
 
     private func sourceNavigationPill(user: User, text: String) -> some View {
@@ -240,7 +240,7 @@ struct RecipeHeaderSection: View {
             .foregroundColor(.secondary)
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
-            .background(.ultraThinMaterial, in: Capsule())
+            .glassEffect(.regular, in: Capsule())
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)

--- a/Cauldron/Features/Library/Components/RecipeHeaderSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeHeaderSection.swift
@@ -131,7 +131,7 @@ struct RecipeHeaderSection: View {
                         .padding(8)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(warning.color.opacity(0.1))
-                        .cornerRadius(8)
+                        .cornerRadius(Theme.Radius.small)
                     }
                 }
                 .padding(.top, 4)

--- a/Cauldron/Features/Library/Components/RecipeNutritionSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeNutritionSection.swift
@@ -49,7 +49,7 @@ private struct NutritionItem: View {
         .frame(maxWidth: .infinity)
         .padding()
         .background(Color.cauldronOrange.opacity(0.1))
-        .cornerRadius(8)
+        .cornerRadius(Theme.Radius.small)
     }
 }
 

--- a/Cauldron/Features/Library/Components/RecipeStepsSection.swift
+++ b/Cauldron/Features/Library/Components/RecipeStepsSection.swift
@@ -100,7 +100,7 @@ private struct StepRow: View {
         .padding(.vertical, 8)
         .padding(.horizontal, 12)
         .background(isHighlighted ? Color.cauldronOrange.opacity(0.15) : Color.clear)
-        .cornerRadius(12)
+        .cornerRadius(Theme.Radius.card)
         .id("step-\(step.index)")
     }
 }

--- a/Cauldron/Features/Library/RecipeEditorView.swift
+++ b/Cauldron/Features/Library/RecipeEditorView.swift
@@ -156,7 +156,7 @@ struct RecipeEditorView: View {
                     .scaledToFill()
                     .frame(maxWidth: .infinity)
                     .frame(height: 240)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.card))
                     .clipped()
                 
                 // Change/Remove image button
@@ -181,7 +181,7 @@ struct RecipeEditorView: View {
                 Button {
                     showingImageOptions = true
                 } label: {
-                    RoundedRectangle(cornerRadius: 12)
+                    RoundedRectangle(cornerRadius: Theme.Radius.card)
                         .fill(Color.appSurface)
                         .frame(height: 200)
                         .overlay {
@@ -407,7 +407,7 @@ struct RecipeEditorView: View {
                 }
                 .padding(12)
                 .background(Color(.secondarySystemGroupedBackground))
-                .cornerRadius(12)
+                .cornerRadius(Theme.Radius.card)
                 .padding(.vertical, 4)
                 .overlay(alignment: .topLeading) {
                 }
@@ -518,7 +518,7 @@ struct RecipeEditorView: View {
                 }
                 .padding(12)
                 .background(Color(.secondarySystemGroupedBackground))
-                .cornerRadius(12)
+                .cornerRadius(Theme.Radius.card)
                 .padding(.vertical, 4)
             }
             
@@ -782,9 +782,9 @@ struct StepEditorRow: View {
                 .frame(minHeight: 80)
                 .padding(8)
                 .background(Color.appSurface)
-                .cornerRadius(8)
+                .cornerRadius(Theme.Radius.small)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 8)
+                    RoundedRectangle(cornerRadius: Theme.Radius.small)
                         .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
                 )
             
@@ -870,7 +870,7 @@ struct TimerEditorRow: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
         .background(Color.appSurface)
-        .cornerRadius(8)
+        .cornerRadius(Theme.Radius.small)
         .onAppear {
             // Initialize display value based on seconds
             if timer.seconds >= 3600 && timer.seconds % 3600 == 0 {

--- a/Cauldron/Features/Profile/EditProfileView.swift
+++ b/Cauldron/Features/Profile/EditProfileView.swift
@@ -277,7 +277,7 @@ struct ProfileEditView: View {
                             } label: {
                                 HStack {
                                     Image(systemName: "exclamationmark.triangle.fill")
-                                        .foregroundColor(.orange)
+                                        .foregroundColor(.cauldronOrange)
                                     Text("Delete Account")
                                         .foregroundColor(.primary)
                                     Spacer()

--- a/Cauldron/Features/Profile/EditProfileView.swift
+++ b/Cauldron/Features/Profile/EditProfileView.swift
@@ -203,7 +203,7 @@ struct ProfileEditView: View {
                                 .textCase(.lowercase)
                                 .padding()
                                 .background(Color.cauldronSecondaryBackground)
-                                .cornerRadius(12)
+                                .cornerRadius(Theme.Radius.card)
 
                             Text("3-20 characters, letters, numbers, and underscores only")
                                 .font(.caption)
@@ -220,7 +220,7 @@ struct ProfileEditView: View {
                                 .textInputAutocapitalization(.words)
                                 .padding()
                                 .background(Color.cauldronSecondaryBackground)
-                                .cornerRadius(12)
+                                .cornerRadius(Theme.Radius.card)
 
                             Text("This is how others will see you")
                                 .font(.caption)
@@ -261,7 +261,7 @@ struct ProfileEditView: View {
                                 }
                                 .padding()
                                 .background(Color.cauldronSecondaryBackground)
-                                .cornerRadius(12)
+                                .cornerRadius(Theme.Radius.card)
                             }
                             .buttonStyle(.plain)
                         }
@@ -287,7 +287,7 @@ struct ProfileEditView: View {
                                 }
                                 .padding()
                                 .background(Color.cauldronSecondaryBackground)
-                                .cornerRadius(12)
+                                .cornerRadius(Theme.Radius.card)
                             }
                             .buttonStyle(.plain)
                         }

--- a/Cauldron/Features/Profile/UserProfileView.swift
+++ b/Cauldron/Features/Profile/UserProfileView.swift
@@ -256,11 +256,11 @@ struct UserProfileView: View {
                         .resizable()
                         .scaledToFit()
                         .frame(width: 56, height: 56)
-                        .cornerRadius(12)
+                        .cornerRadius(Theme.Radius.card)
                         .blur(radius: isUnlocked ? 0 : 3)
                         .opacity(isUnlocked ? 1.0 : 0.5)
                         .overlay(
-                            RoundedRectangle(cornerRadius: 12)
+                            RoundedRectangle(cornerRadius: Theme.Radius.card)
                                 .stroke(isSelected ? Color.cauldronOrange : Color.clear, lineWidth: 2)
                         )
 
@@ -434,7 +434,7 @@ struct UserProfileView: View {
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
                     .background(Color.green.opacity(0.15))
-                    .cornerRadius(8)
+                    .cornerRadius(Theme.Radius.small)
                 }
 
             case .pendingOutgoing:
@@ -459,7 +459,7 @@ struct UserProfileView: View {
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
                     .background(Color.cauldronOrange.opacity(0.15))
-                    .cornerRadius(8)
+                    .cornerRadius(Theme.Radius.small)
                 }
 
             case .pendingIncoming:
@@ -475,7 +475,7 @@ struct UserProfileView: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
                 .background(Color.blue.opacity(0.15))
-                .cornerRadius(8)
+                .cornerRadius(Theme.Radius.small)
 
             case .none:
                 // Add Friend badge - tap to send request
@@ -495,7 +495,7 @@ struct UserProfileView: View {
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
                     .background(Color.cauldronOrange.opacity(0.15))
-                    .cornerRadius(8)
+                    .cornerRadius(Theme.Radius.small)
                 }
 
             case .syncing:
@@ -519,7 +519,7 @@ struct UserProfileView: View {
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
                     .background(Color.cauldronOrange.opacity(0.15))
-                    .cornerRadius(8)
+                    .cornerRadius(Theme.Radius.small)
                 }
 
             case .currentUser:

--- a/Cauldron/Features/Profile/UserProfileView.swift
+++ b/Cauldron/Features/Profile/UserProfileView.swift
@@ -455,10 +455,10 @@ struct UserProfileView: View {
                             .font(.caption)
                             .fontWeight(.medium)
                     }
-                    .foregroundColor(.orange)
+                    .foregroundColor(.cauldronOrange)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(Color.orange.opacity(0.15))
+                    .background(Color.cauldronOrange.opacity(0.15))
                     .cornerRadius(8)
                 }
 
@@ -515,10 +515,10 @@ struct UserProfileView: View {
                             .font(.caption)
                             .fontWeight(.medium)
                     }
-                    .foregroundColor(.orange)
+                    .foregroundColor(.cauldronOrange)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(Color.orange.opacity(0.15))
+                    .background(Color.cauldronOrange.opacity(0.15))
                     .cornerRadius(8)
                 }
 

--- a/Cauldron/Features/Search/ExploreTagView.swift
+++ b/Cauldron/Features/Search/ExploreTagView.swift
@@ -294,7 +294,7 @@ private struct ExploreTagRecipeCardPlaceholder: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            RoundedRectangle(cornerRadius: 16)
+            RoundedRectangle(cornerRadius: Theme.Radius.large)
                 .fill(placeholderFill)
                 .frame(width: cardWidth, height: cardHeight)
 

--- a/Cauldron/Features/Search/SearchTabView.swift
+++ b/Cauldron/Features/Search/SearchTabView.swift
@@ -578,7 +578,7 @@ struct UserSearchRowView: View {
             } label: {
                 HStack(spacing: Theme.Spacing.xxs) {
                     Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(.orange)
+                        .foregroundColor(.cauldronOrange)
                     Text("Retry")
                         .font(.caption)
                 }

--- a/Cauldron/Features/Search/SearchTabView.swift
+++ b/Cauldron/Features/Search/SearchTabView.swift
@@ -333,7 +333,8 @@ struct SearchTabView: View {
 
     /// Time filter + sort controls shown above recipe results.
     private var refinementBar: some View {
-        HStack(spacing: Theme.Spacing.sm) {
+        GlassEffectContainer(spacing: Theme.Spacing.sm) {
+            HStack(spacing: Theme.Spacing.sm) {
             Menu {
                 Picker("Time", selection: $viewModel.timeFilter) {
                     ForEach(RecipeTimeFilter.allCases) { filter in
@@ -373,6 +374,7 @@ struct SearchTabView: View {
             }
 
             Spacer()
+            }
         }
     }
 
@@ -387,13 +389,10 @@ struct SearchTabView: View {
         .foregroundStyle(isActive ? Color.cauldronOrange : Color.primary)
         .padding(.horizontal, Theme.Spacing.sm)
         .padding(.vertical, Theme.Spacing.xs)
-        .background {
-            if isActive {
-                Capsule().fill(Color.cauldronOrange.opacity(0.15))
-            } else {
-                Capsule().fill(.ultraThinMaterial)
-            }
-        }
+        .glassEffect(
+            isActive ? .regular.tint(Color.cauldronOrange.opacity(0.25)) : .regular,
+            in: Capsule()
+        )
     }
     
     private var peopleSearchView: some View {

--- a/Cauldron/Features/Settings/AppIconPickerView.swift
+++ b/Cauldron/Features/Settings/AppIconPickerView.swift
@@ -72,7 +72,7 @@ struct AppIconPickerView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: 52, height: 52)
-                    .cornerRadius(12)
+                    .cornerRadius(Theme.Radius.card)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(iconManager.currentTheme.name)
@@ -125,7 +125,7 @@ struct AppIconPickerView: View {
         }
         .padding()
         .background(Color.cauldronSecondaryBackground)
-        .cornerRadius(16)
+        .cornerRadius(Theme.Radius.large)
     }
 
     // MARK: - Icons Grid
@@ -164,9 +164,9 @@ struct AppIconPickerView: View {
                             .resizable()
                             .scaledToFit()
                             .frame(width: 72, height: 72)
-                            .cornerRadius(16)
+                            .cornerRadius(Theme.Radius.large)
                             .overlay(
-                                RoundedRectangle(cornerRadius: 16)
+                                RoundedRectangle(cornerRadius: Theme.Radius.large)
                                     .stroke(isSelected ? Color.cauldronOrange : Color.clear, lineWidth: 3)
                             )
                     } else {
@@ -175,7 +175,7 @@ struct AppIconPickerView: View {
                             .resizable()
                             .scaledToFit()
                             .frame(width: 72, height: 72)
-                            .cornerRadius(16)
+                            .cornerRadius(Theme.Radius.large)
                             .blur(radius: 4)
                             .saturation(0.3)
                             .opacity(0.6)

--- a/Cauldron/Features/Settings/AppIconPickerView.swift
+++ b/Cauldron/Features/Settings/AppIconPickerView.swift
@@ -56,7 +56,7 @@ struct AppIconPickerView: View {
                         .overlay {
                             ProgressView("Changing icon...")
                                 .padding()
-                                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+                                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
                         }
                 }
             }

--- a/Cauldron/Features/Settings/AvatarCustomizationSheet.swift
+++ b/Cauldron/Features/Settings/AvatarCustomizationSheet.swift
@@ -77,7 +77,7 @@ struct AvatarCustomizationSheet: View {
         .frame(maxWidth: .infinity)
         .padding()
         .background(Color.cauldronSecondaryBackground)
-        .cornerRadius(12)
+        .cornerRadius(Theme.Radius.card)
     }
 
     private var emojiSection: some View {
@@ -95,7 +95,7 @@ struct AvatarCustomizationSheet: View {
                             .font(.title2)
                             .frame(width: 44, height: 44)
                             .background(selectedEmoji == emoji ? Color.cauldronOrange.opacity(0.2) : Color.cauldronSecondaryBackground)
-                            .cornerRadius(8)
+                            .cornerRadius(Theme.Radius.small)
                     }
                     .buttonStyle(.plain)
                 }

--- a/Cauldron/Features/Settings/ProfileSheet.swift
+++ b/Cauldron/Features/Settings/ProfileSheet.swift
@@ -109,7 +109,7 @@ struct ProfileSheet: View {
                             .padding(.horizontal, 10)
                             .padding(.vertical, 4)
                             .background(Color.cauldronOrange.opacity(0.1))
-                            .cornerRadius(12)
+                            .cornerRadius(Theme.Radius.card)
                         }
                     }
                 }
@@ -132,7 +132,7 @@ struct ProfileSheet: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 4)
         .background(tier.color.opacity(0.15))
-        .cornerRadius(12)
+        .cornerRadius(Theme.Radius.card)
     }
 
     // MARK: - Referral Section
@@ -183,7 +183,7 @@ struct ProfileSheet: View {
                             .padding(.horizontal, 20)
                             .padding(.vertical, 12)
                             .background(Color.cauldronOrange.opacity(0.1))
-                            .cornerRadius(12)
+                            .cornerRadius(Theme.Radius.card)
                         }
                         .buttonStyle(.plain)
 
@@ -211,7 +211,7 @@ struct ProfileSheet: View {
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 14)
                         .background(Color.cauldronOrange)
-                        .cornerRadius(12)
+                        .cornerRadius(Theme.Radius.card)
                     }
                     .buttonStyle(.plain)
 
@@ -220,7 +220,7 @@ struct ProfileSheet: View {
         }
         .padding()
         .background(Color.cauldronSecondaryBackground)
-        .cornerRadius(16)
+        .cornerRadius(Theme.Radius.large)
     }
 
     // MARK: - Progress Ring
@@ -358,7 +358,7 @@ struct ProfileSheet: View {
                 }
                 .padding()
                 .background(Color.cauldronSecondaryBackground)
-                .cornerRadius(12)
+                .cornerRadius(Theme.Radius.card)
             }
             .buttonStyle(.plain)
         }
@@ -387,7 +387,7 @@ struct ProfileSheet: View {
             }
             .padding(.vertical, 12)
             .background(Color.cauldronSecondaryBackground)
-            .cornerRadius(12)
+            .cornerRadius(Theme.Radius.card)
         }
     }
 
@@ -426,7 +426,7 @@ struct ProfileSheet: View {
                     }
                     .padding()
                     .background(Color.cauldronSecondaryBackground)
-                    .cornerRadius(12)
+                    .cornerRadius(Theme.Radius.card)
                 }
                 .buttonStyle(.plain)
             }
@@ -446,7 +446,7 @@ struct ProfileSheet: View {
                 }
                 .padding()
                 .background(Color.cauldronSecondaryBackground)
-                .cornerRadius(12)
+                .cornerRadius(Theme.Radius.card)
             }
             .buttonStyle(.plain)
         }

--- a/Cauldron/Features/Settings/WelcomeView.swift
+++ b/Cauldron/Features/Settings/WelcomeView.swift
@@ -23,7 +23,7 @@ struct WelcomeView: View {
                         .resizable()
                         .scaledToFit()
                         .frame(width: 72, height: 72)
-                        .cornerRadius(16)
+                        .cornerRadius(Theme.Radius.large)
 
                     VStack(spacing: 8) {
                         Text("Welcome to Cauldron")

--- a/Cauldron/Features/Settings/WelcomeView.swift
+++ b/Cauldron/Features/Settings/WelcomeView.swift
@@ -45,7 +45,7 @@ struct WelcomeView: View {
                         )
                         FeatureRow(
                             symbol: "timer",
-                            color: .orange,
+                            color: .cauldronOrange,
                             title: "Cook Mode",
                             detail: "Hands-free cooking with step-by-step instructions and built-in timers."
                         )

--- a/Cauldron/Features/Settings/WhatsNewView.swift
+++ b/Cauldron/Features/Settings/WhatsNewView.swift
@@ -51,7 +51,7 @@ struct WhatsNewView: View {
                         )
                         FeatureRow(
                             symbol: "list.bullet.rectangle",
-                            color: .orange,
+                            color: .cauldronOrange,
                             title: "Cleaner Recipe Details",
                             detail: "Related recipes, saved recipes, and preview recipes now behave more consistently across your library."
                         )

--- a/Cauldron/Features/Settings/WhatsNewView.swift
+++ b/Cauldron/Features/Settings/WhatsNewView.swift
@@ -23,7 +23,7 @@ struct WhatsNewView: View {
                         .resizable()
                         .scaledToFit()
                         .frame(width: 72, height: 72)
-                        .cornerRadius(16)
+                        .cornerRadius(Theme.Radius.large)
 
                     VStack(spacing: 8) {
                         Text("What's New")

--- a/Cauldron/Features/Settings/iCloudSignInPromptView.swift
+++ b/Cauldron/Features/Settings/iCloudSignInPromptView.swift
@@ -52,7 +52,7 @@ struct iCloudSignInPromptView: View {
                         .padding()
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .background(Color.cauldronOrange.opacity(0.1))
-                        .cornerRadius(12)
+                        .cornerRadius(Theme.Radius.card)
                         .padding(.horizontal)
                         .padding(.top, 8)
                     }
@@ -82,7 +82,7 @@ struct iCloudSignInPromptView: View {
                         .padding()
                         .background(Color.cauldronOrange)
                         .foregroundColor(.white)
-                        .cornerRadius(12)
+                        .cornerRadius(Theme.Radius.card)
                     }
                     .disabled(isRetrying)
                 }

--- a/Cauldron/Features/Sharing/ConnectionsView.swift
+++ b/Cauldron/Features/Sharing/ConnectionsView.swift
@@ -209,7 +209,7 @@ struct ConnectionRequestCard: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(Color.cauldronOrange.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .background(Color.cauldronOrange.opacity(0.08), in: RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
         .padding(.horizontal, 16)
         .padding(.vertical, 2)
     }
@@ -247,7 +247,7 @@ struct ConnectionCard: View {
             }
             .padding(16)
             .background(Color.cauldronSecondaryBackground)
-            .cornerRadius(16)
+            .cornerRadius(Theme.Radius.large)
             .shadow(color: .black.opacity(0.04), radius: 6, x: 0, y: 2)
             .padding(.horizontal, 16)
             .padding(.vertical, 6)
@@ -296,7 +296,7 @@ struct SentRequestCard: View {
             }
             .padding(16)
             .background(Color.cauldronSecondaryBackground)
-            .cornerRadius(16)
+            .cornerRadius(Theme.Radius.large)
             .shadow(color: .black.opacity(0.04), radius: 6, x: 0, y: 2)
             .padding(.horizontal, 16)
             .padding(.vertical, 6)

--- a/Cauldron/Features/Sharing/FriendsTabView.swift
+++ b/Cauldron/Features/Sharing/FriendsTabView.swift
@@ -337,7 +337,7 @@ struct FriendsTabView: View {
             .padding(.vertical, 50)
         }
         .background(Color.cauldronSecondaryBackground)
-        .cornerRadius(16)
+        .cornerRadius(Theme.Radius.large)
         .padding(.horizontal, 16)
     }
 

--- a/Cauldron/Features/Sharing/PeopleSearchSheet.swift
+++ b/Cauldron/Features/Sharing/PeopleSearchSheet.swift
@@ -321,7 +321,7 @@ struct PeopleSearchUserRow: View {
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(.orange)
+                        .foregroundColor(.cauldronOrange)
                     Text("Retry")
                         .font(.caption)
                 }

--- a/Cauldron/Features/Sharing/PeopleSearchSheet.swift
+++ b/Cauldron/Features/Sharing/PeopleSearchSheet.swift
@@ -271,7 +271,7 @@ struct PeopleSearchUserRow: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
                 .background(Color.blue.opacity(0.1))
-                .cornerRadius(8)
+                .cornerRadius(Theme.Radius.small)
 
         case .pendingIncoming:
             HStack(spacing: 8) {


### PR DESCRIPTION
Follow-up polish on top of #72, addressing review feedback.

## Changes
- **Tier color** — Head Chef's pure gold (`#FFD700`) was nearly invisible as the current-tier highlight/icon on the warm paper canvas. Swapped for a deeper amber-gold (`#E8A317`) that keeps the gold-trophy identity but reads clearly.
- **Color tokens** — migrated 21 raw `.orange` accents to the warm `.cauldronOrange` brand token across What's New, Welcome, People search, AI generator, Search, Profile, Edit profile, conformance fix, collection detail, and the import preview sheet. Intentional non-accent colors (favorite gold stars, category palette, semantic warnings) left as-is.
- **Native Liquid Glass** — replaced `ultraThinMaterial`/`regularMaterial` surfaces with native `glassEffect`: recipe header favorite/source pills, AI streaming-preview cards + error card, collection reference badges, the app-icon change HUD, and the Search Time/Sort refinement chips (wrapped in a `GlassEffectContainer` so the adjacent pills don't morph).
- **Radius tokens** — migrated 74 hardcoded corner radii (`8/12/16/20`) to the matching `Theme.Radius` tokens across 29 view files. Pure rename, identical values, no visual change; off-token radii left as deliberate one-offs.

## Verification
- Build green on iPhone 17 Pro simulator.
- Visual QA in the simulator: tier list (amber legible), recipe header glass star/pills, Search glass refinement chips (no morphing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)