### PR TITLE
Validate exact image origins in hosted SEO audit

### DIFF
--- a/firebase/functions/test/webOptimization.test.mjs
+++ b/firebase/functions/test/webOptimization.test.mjs
@@ -7,6 +7,9 @@ test("SEO image audit requires nonempty, well-formed exact-origin URLs", () => {
     assert.equal(hasSameOriginImages(["https://CAULDRONRECIPES.com:443/recipe/id/image/640.webp"], origin), true);
     for (const images of [undefined, null, [], "not an array", [null], [42], [{}],
         ["/recipe/id/image/640.webp"], ["not a URL"],
+        ["blob:https://cauldronrecipes.com/recipe-image"],
+        ["data:image/png;base64,AAAA"],
+        ["javascript:alert(1)"],
         ["http://cauldronrecipes.com/image.png"],
         ["https://cauldronrecipes.com.attacker.example/image.png"],
         ["https://cauldronrecipes.com@attacker.example/image.png"],

--- a/firebase/functions/test/webOptimization.test.mjs
+++ b/firebase/functions/test/webOptimization.test.mjs
@@ -1,4 +1,22 @@
 import test from "node:test";
+import { hasSameOriginImages } from "../tools/publicImageAudit.mjs";
+
+test("SEO image audit requires nonempty, well-formed exact-origin URLs", () => {
+    const origin = "https://cauldronrecipes.com";
+    assert.equal(hasSameOriginImages([`${origin}/recipe/id/social-card.png`], origin), true);
+    assert.equal(hasSameOriginImages(["https://CAULDRONRECIPES.com:443/recipe/id/image/640.webp"], origin), true);
+    for (const images of [undefined, null, [], "not an array", [null], [42], [{}],
+        ["/recipe/id/image/640.webp"], ["not a URL"],
+        ["http://cauldronrecipes.com/image.png"],
+        ["https://cauldronrecipes.com.attacker.example/image.png"],
+        ["https://cauldronrecipes.com@attacker.example/image.png"],
+        ["https://attacker.example/?https://cauldronrecipes.com"],
+        ["https://cauldronrecipes.com:444/image.png"],
+        ["https://user:password@cauldronrecipes.com/image.png"],
+        [`${origin}/image.png`, "https://attacker.example/image.png"]]) {
+        assert.equal(hasSameOriginImages(images, origin), false);
+    }
+});
 import assert from "node:assert/strict";
 import sharp from "sharp";
 import { RecipeImageCache, recipeImageWidth, recipeImageRevisionKey, readBoundedImage, resizeRecipeImage } from "../lib/recipeImages.js";

--- a/firebase/functions/tools/auditHostedWeb.mjs
+++ b/firebase/functions/tools/auditHostedWeb.mjs
@@ -1,4 +1,5 @@
 // Small, read-only lab audit. These timings are not field Core Web Vitals.
+import { hasSameOriginImages } from "./publicImageAudit.mjs";
 const origin = "https://cauldronrecipes.com";
 const routes = ["/", "/u/nadav", "/recipe/7DBEAFFD-895F-43B1-9985-463F36EA5D8C",
     "/collection/9B0D2D38-3B17-406A-83EC-3F35B21BDB42", "/invite",
@@ -25,7 +26,7 @@ for (const route of routes) {
         externalScripts: (html.match(/<script[^>]*src=/g) || []).length,
         externalStylesheets: (html.match(/<link[^>]*rel="stylesheet"/g) || []).length,
         schemas: schema.map(s => ({ type: s["@type"], invalid: s.invalidJSON || false,
-            author: Boolean(s.author), stableImage: Array.isArray(s.image) && s.image.every(i => i.startsWith(origin)),
+            author: Boolean(s.author), stableImage: hasSameOriginImages(s.image, origin),
             ingredients: s.recipeIngredient?.length, steps: s.recipeInstructions?.length })),
         sitemapURLs: route === "/sitemap.xml" ? (html.match(/<loc>/g) || []).length : undefined,
     }));

--- a/firebase/functions/tools/publicImageAudit.mjs
+++ b/firebase/functions/tools/publicImageAudit.mjs
@@ -1,0 +1,13 @@
+// This reports audit metadata; production image authorization is separate.
+export function hasSameOriginImages(images, expectedOrigin) {
+    if (!Array.isArray(images) || images.length === 0) return false;
+    return images.every(value => {
+        if (typeof value !== "string") return false;
+        try {
+            const url = new URL(value);
+            return url.origin === expectedOrigin && !url.username && !url.password;
+        } catch {
+            return false;
+        }
+    });
+}

--- a/firebase/functions/tools/publicImageAudit.mjs
+++ b/firebase/functions/tools/publicImageAudit.mjs
@@ -5,7 +5,7 @@ export function hasSameOriginImages(images, expectedOrigin) {
         if (typeof value !== "string") return false;
         try {
             const url = new URL(value);
-            return url.origin === expectedOrigin && !url.username && !url.password;
+            return url.protocol === "https:" && url.origin === expectedOrigin && !url.username && !url.password;
         } catch {
             return false;
         }


### PR DESCRIPTION
Fix the first full-main CodeQL finding in the read-only SEO audit tool. Use URL origin equality instead of a string prefix; reject malformed URLs, credentials, empty image arrays, lookalike domains, and mixed-origin arrays. Production authorization and application behavior are unchanged. TypeScript build and all 76 web contract/optimization tests pass locally, including new adversarial URL cases.